### PR TITLE
Do not attend to current timestep in TFT

### DIFF
--- a/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
@@ -431,9 +431,9 @@ class InterpretableMultiHeadAttention(nn.Module):
         self.d_k = self.d_q = self.d_v = d_model // n_head
         self.dropout = nn.Dropout(p=dropout)
 
-        self.v_layer = nn.Linear(self.d_model, self.d_v, bias=False)
-        self.q_layers = nn.ModuleList([nn.Linear(self.d_model, self.d_q, bias=False) for _ in range(self.n_head)])
-        self.k_layers = nn.ModuleList([nn.Linear(self.d_model, self.d_k, bias=False) for _ in range(self.n_head)])
+        self.v_layer = nn.Linear(self.d_model, self.d_v)
+        self.q_layers = nn.ModuleList([nn.Linear(self.d_model, self.d_q) for _ in range(self.n_head)])
+        self.k_layers = nn.ModuleList([nn.Linear(self.d_model, self.d_k) for _ in range(self.n_head)])
         self.attention = ScaledDotProductAttention()
         self.w_h = nn.Linear(self.d_v, self.d_model, bias=False)
 


### PR DESCRIPTION
If different encoder lengths are fed to TFT, the attention on the time steps that it is predicting for varies. It is better to not attend to itself so that the attention is solely on the encoder