### PR TITLE
Removed duplicate forward pass for decoder LSTM

### DIFF
--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -506,14 +506,6 @@ class TemporalFusionTransformer(BaseModel, CovariatesMixin):
             (hidden, cell),
         )
 
-        decoder_output, _ = rnn.pad_packed_sequence(decoder_output, batch_first=True)
-
-        # run local decoder
-        decoder_output, _ = self.lstm_decoder(
-            embeddings_varying_decoder,
-            (hidden, cell),
-        )
-
         # skip connection over lstm
         lstm_output_encoder = self.post_lstm_gate_encoder(encoder_output)
         lstm_output_encoder = self.post_lstm_add_norm_encoder(lstm_output_encoder, embeddings_varying_encoder)

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -505,7 +505,7 @@ class TemporalFusionTransformer(BaseModel, CovariatesMixin):
             ),
             (hidden, cell),
         )
-        
+
         decoder_output, _ = rnn.pad_packed_sequence(decoder_output, batch_first=True)
 
         # skip connection over lstm

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -505,6 +505,8 @@ class TemporalFusionTransformer(BaseModel, CovariatesMixin):
             ),
             (hidden, cell),
         )
+        
+        decoder_output, _ = rnn.pad_packed_sequence(decoder_output, batch_first=True)
 
         # skip connection over lstm
         lstm_output_encoder = self.post_lstm_gate_encoder(encoder_output)


### PR DESCRIPTION
There were two forward passes for the decoder LSTM, which waste (actually a lot) of CPU/GPU cycles.

