### PR TITLE
BaseModel.predict() properly moves inputs to device

### DIFF
--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -555,7 +555,7 @@ class BaseModel(LightningModule):
                 # move data to appropriate device
                 for name in x.keys():
                     if x[name].device != self.device:
-                        x[name].to(self.device)
+                        x[name] = x[name].to(self.device)
 
                 # make prediction
                 out = self(x)  # raw output is dictionary


### PR DESCRIPTION
### Fixes

- Fixes issue bug when trying to make predictions with model / data that are not on the same device

https://stackoverflow.com/questions/59560043/what-is-the-difference-between-model-todevice-and-model-model-todevice