### PR TITLE
Bugfix/basemodel handles non tensor raw predictions

### DIFF
--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -653,7 +653,8 @@ class BaseModel(LightningModule):
             output = torch.cat(output, dim=0)
         elif mode == "raw":
             output_cat = {}
-            for name in output[0].keys():
+            tensor_keys = [key for key, item in output[0].items() if isinstance(item, torch.Tensor)]
+            for name in tensor_keys:
                 output_cat[name] = torch.cat([out[name] for out in output], dim=0)
             output = output_cat
 

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -653,9 +653,15 @@ class BaseModel(LightningModule):
             output = torch.cat(output, dim=0)
         elif mode == "raw":
             output_cat = {}
-            tensor_keys = [key for key, item in output[0].items() if isinstance(item, torch.Tensor)]
-            for name in tensor_keys:
-                output_cat[name] = torch.cat([out[name] for out in output], dim=0)
+            for name in output[0].keys():
+                v0 = output[0][name]
+                if isinstance(v0, torch.Tensor):
+                    output_cat[name] = torch.cat([out[name] for out in output], dim=0)
+                else:
+                    try:
+                        output_cat[name] = np.concatenate([out[name] for out in output], axis=0)
+                    except ValueError:
+                        output_cat[name] = [out[name] for out in output]
             output = output_cat
 
         # generate output


### PR DESCRIPTION
DeepAR output contains a string value which can not be concatenated with torch.cat(). This MR resolves this by only concatenating values which are torch.Tensors