### PR TITLE
Fixed self.norm_ in GroupEncoder in fit method

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -547,7 +547,7 @@ class GroupNormalizer(TorchNormalizer):
                     norm["center"] = 0.0
                     return norm
 
-                self.norm = {g: swap_parameters(norm) for g, norm in self.norm_.items()}
+                self.norm_ = {g: swap_parameters(norm) for g, norm in self.norm_.items()}
             self.missing_ = {group: scales.median().to_dict() for group, scales in self.norm_.items()}
 
         else:


### PR DESCRIPTION
I think you forgot to add an underscore to self.norm_ atribute of the GroupEncoder.