### PR TITLE
Found bug when filtering data with min_prediction_id, and fixed an in…

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -336,7 +336,7 @@ class TimeSeriesDataSet(Dataset):
         # set data
         assert data.index.is_unique, "data index has to be unique"
         if min_prediction_idx is not None:
-            data = data[lambda x: data[self.time_idx] >= self.min_prediction_idx - self.max_encoder_length]
+            data = data[lambda x: data[self.time_idx] >= self.min_prediction_idx - self.min_encoder_length]
         data = data.sort_values(self.group_ids + [self.time_idx])
 
         # add time index relative to prediction position
@@ -398,10 +398,10 @@ class TimeSeriesDataSet(Dataset):
                         normalizers.append(EncoderNormalizer(transformation=transformer))
                     else:
                         normalizers.append(GroupNormalizer(transformation=transformer))
-                if self.multi_target:
-                    self.target_normalizer = MultiNormalizer(normalizers)
-                else:
-                    self.target_normalizer = normalizers[0]
+            if self.multi_target:
+                self.target_normalizer = MultiNormalizer(normalizers)
+            else:
+                self.target_normalizer = normalizers[0]
         elif self.target_normalizer is None:
             self.target_normalizer = TorchNormalizer(method="identity")
         assert self.min_encoder_length > 1 or not isinstance(


### PR DESCRIPTION
Found an issue in the __init__ of TimeSeriesDataSet.

Original:
`data = data[lambda x: data[self.time_idx] >= self.min_prediction_idx - self.max_encoder_length]`

Changed: 
`data = data[lambda x: data[self.time_idx] >= self.min_prediction_idx - self.min_encoder_length]`

For example, we have time_idx 1, 2, 3, 4, 5, 6, 7 and:
* `min_encoder_length = 2`
* `min_prediction_length = 1`
* `max_encoder_length = 3`
* `min_prediction_idx = 6`

Then with the original code, the mininum time_idx would be 6 - 3 = 3, so it would be possible to have 3, 4 as encoder idxs and 5 as decoder idx, which is before `min_prediction_idx`.

With the changed code, the mininum time_idx would be 6 - 2 = 4, and since `min_encoder_length = 2`, the first prediction idx is always after 6.

I also saw that in _set_target_normalizer I moved `if self.multi_target:...` back an indent so it makes more sense.



