### PR TITLE
Handling `return_x=True` in case of multi-target prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@
 
 - Underlying data is copied if modified. Original data is not modified inplace (#263)
 - Allow plotting of interpretation on passed figure for NBEATS (#280)
+- Correct shape of `predict()` method output for multi-targets (#268)
 
 ### Contributors
 
 - jdb78
 - kigawas
+- snumumrik
 
 ## v0.8.2 Fix for output transformer (12/01/2021)
 

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -542,6 +542,10 @@ class TimeSeriesDataSet(Dataset):
         assert isinstance(
             self.target_normalizer, (TorchNormalizer, NaNLabelEncoder)
         ), f"target_normalizer has to be either None or of class TorchNormalizer but found {self.target_normalizer}"
+        assert not self.multi_target or isinstance(self.target_normalizer, MultiNormalizer), (
+            "multiple targets / list of targets requires MultiNormalizer as target_normalizer "
+            f"but found {self.target_normalizer}"
+        )
 
     @property
     @lru_cache(None)

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -818,11 +818,13 @@ class BaseModel(LightningModule):
                 elif isinstance(v0, (tuple, list)) and len(v0) > 0 and isinstance(v0[0], torch.Tensor):
 
                     output_cat[name] = []
-                    for k in range(len(v0)):
-                        output_cat[name].append(torch.cat([out[name][k] for out in output], dim=0))
+                    for target_id in range(len(v0)):
+                        output_cat[name].append(torch.cat([out[name][target_id] for out in output], dim=0))
                 else:
                     try:
-                        output_cat[name] = np.concatenate([out[name] for out in output], axis=0)
+                        output_cat[name] = []
+                        for target_id in range(len(v0)):
+                            output_cat[name].append(np.concatenate([out[name][target_id] for out in output], axis=0))
                     except ValueError:
                         output_cat[name] = [out[name] for out in output]
             output = output_cat
@@ -835,16 +837,18 @@ class BaseModel(LightningModule):
             for name in x_list[0].keys():
                 v0 = x_list[0][name]
                 if isinstance(v0, torch.Tensor):
-                    x_cat[name] = torch.cat([out[name] for out in x_list], dim=0)
+                    x_cat[name] = torch.cat([x_values[name] for x_values in x_list], dim=0)
                 elif isinstance(v0, (tuple, list)) and len(v0) > 0 and isinstance(v0[0], torch.Tensor):
                     x_cat[name] = []
-                    for k in range(len(v0)):
-                        x_cat[name].append(torch.cat([out[name][k] for out in x_list], dim=0))
+                    for target_id in range(len(v0)):
+                        x_cat[name].append(torch.cat([x_values[name][target_id] for x_values in x_list], dim=0))
                 else:
                     try:
-                        x_cat[name] = np.concatenate([out[name] for out in x_list], axis=0)
+                        x_cat[name] = []
+                        for target_id in range(len(v0)):
+                            x_cat[name].append(np.concatenate([x_values[name][target_id] for x_values in x_list], axis=0))
                     except ValueError:
-                        x_cat[name] = [out[name] for out in x_list]
+                        x_cat[name] = [x_values[name] for x_values in x_list]
             x_cat = x_cat
             output.append(x_cat)
         if return_index:

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -26,6 +26,70 @@ from pytorch_forecasting.optim import Ranger
 from pytorch_forecasting.utils import apply_to_list, create_mask, get_embedding_size, groupby_apply, to_list
 
 
+def _torch_cat_na(x: List[torch.Tensor]) -> torch.Tensor:
+    """
+    Concatenate tensor along ``dim=0`` and add nans along ``dim=1`` if necessary.
+
+    Allows concatenation of tensors where ``dim=1`` are not equal.
+    Missing values are filled up with ``nan``.
+
+    Args:
+        x (List[torch.Tensor]): list of tensors to concatenate along dimension 0
+
+    Returns:
+        torch.Tensor: concatenated tensor
+    """
+    if x[0].ndim > 1:
+        first_lens = [xi.shape[1] for xi in x]
+        max_first_len = max(first_lens)
+        if max_first_len > min(first_lens):
+            x = [
+                xi
+                if xi.shape[1] == max_first_len
+                else torch.cat(
+                    [xi, torch.full((xi.shape[0], max_first_len - xi.shape[1], *xi.shape[2:]), float("nan"))], dim=1
+                )
+                for xi in x
+            ]
+    return torch.cat(x, dim=0)
+
+
+def _concatenate_output(
+    output: List[Dict[str, List[Union[List[torch.Tensor], torch.Tensor, bool, int, str, np.ndarray]]]]
+) -> Dict[str, Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, int, bool, str]]]]:
+    """
+    Concatenate multiple batches of output dictionary.
+
+    Args:
+        output (List[Dict[str, List[Union[List[torch.Tensor], torch.Tensor, bool, int, str, np.ndarray]]]]):
+            list of outputs to concatenate. Each entry corresponds to a batch.
+
+    Returns:
+        Dict[str, Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, int, bool, str]]]]:
+            concatenated output
+    """
+    output_cat = {}
+    for name in output[0].keys():
+        v0 = output[0][name]
+        # concatenate simple tensors
+        if isinstance(v0, torch.Tensor):
+            output_cat[name] = _torch_cat_na([out[name] for out in output])
+        # concatenate list of tensors
+        elif isinstance(v0, (tuple, list)) and len(v0) > 0 and isinstance(v0[0], torch.Tensor):
+            output_cat[name] = []
+            for target_id in range(len(v0)):
+                output_cat[name].append(_torch_cat_na([out[name][target_id] for out in output]))
+        # concatenate everything else
+        else:
+            output_cat[name] = []
+            for target_id in range(len(v0)):
+                try:
+                    output_cat[name].append(np.concatenate([out[name][target_id] for out in output], axis=0))
+                except ValueError:
+                    output_cat[name] = [item for out in output for item in out[name][target_id]]
+    return output_cat
+
+
 class BaseModel(LightningModule):
     """
     BaseModel from which new timeseries models should inherit from.
@@ -672,6 +736,13 @@ class BaseModel(LightningModule):
             kwargs["output_transformer"] = dataset.target_normalizer
         net = cls(**kwargs)
         net.dataset_parameters = dataset.get_parameters()
+        if dataset.multi_target:
+            assert isinstance(
+                net.loss, MultiLoss
+            ), f"multiple targets require loss to be MultiLoss but found {net.loss}"
+        else:
+            assert not isinstance(net.loss, MultiLoss), "MultiLoss not compatible with single target"
+
         return net
 
     def on_save_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
@@ -806,51 +877,17 @@ class BaseModel(LightningModule):
         # concatenate output (of different batches)
         if isinstance(mode, (tuple, list)) or mode != "raw":
             if isinstance(output[0], (tuple, list)) and len(output[0]) > 0 and isinstance(output[0][0], torch.Tensor):
-                output = [torch.cat(out, dim=0) for out in output]
+                output = [_torch_cat_na([out[idx] for out in output]) for idx in range(len(output[0]))]
             else:
-                output = torch.cat(output, dim=0)
+                output = _torch_cat_na(output)
         elif mode == "raw":
-            output_cat = {}
-            for name in output[0].keys():
-                v0 = output[0][name]
-                if isinstance(v0, torch.Tensor):
-                    output_cat[name] = torch.cat([out[name] for out in output], dim=0)
-                elif isinstance(v0, (tuple, list)) and len(v0) > 0 and isinstance(v0[0], torch.Tensor):
-
-                    output_cat[name] = []
-                    for target_id in range(len(v0)):
-                        output_cat[name].append(torch.cat([out[name][target_id] for out in output], dim=0))
-                else:
-                    try:
-                        output_cat[name] = []
-                        for target_id in range(len(v0)):
-                            output_cat[name].append(np.concatenate([out[name][target_id] for out in output], axis=0))
-                    except ValueError:
-                        output_cat[name] = [out[name] for out in output]
-            output = output_cat
+            output = _concatenate_output(output)
 
         # generate output
         if return_x or return_index or return_decoder_lengths:
             output = [output]
         if return_x:
-            x_cat = {}
-            for name in x_list[0].keys():
-                v0 = x_list[0][name]
-                if isinstance(v0, torch.Tensor):
-                    x_cat[name] = torch.cat([x_values[name] for x_values in x_list], dim=0)
-                elif isinstance(v0, (tuple, list)) and len(v0) > 0 and isinstance(v0[0], torch.Tensor):
-                    x_cat[name] = []
-                    for target_id in range(len(v0)):
-                        x_cat[name].append(torch.cat([x_values[name][target_id] for x_values in x_list], dim=0))
-                else:
-                    try:
-                        x_cat[name] = []
-                        for target_id in range(len(v0)):
-                            x_cat[name].append(np.concatenate([x_values[name][target_id] for x_values in x_list], axis=0))
-                    except ValueError:
-                        x_cat[name] = [x_values[name] for x_values in x_list]
-            x_cat = x_cat
-            output.append(x_cat)
+            output.append(_concatenate_output(x_list))
         if return_index:
             output.append(pd.concat(index, axis=0, ignore_index=True))
         if return_decoder_lengths:
@@ -869,7 +906,6 @@ class BaseModel(LightningModule):
     ) -> Union[np.ndarray, torch.Tensor, pd.Series, pd.DataFrame]:
         """
         Predict partial dependency.
-
 
         Args:
             data (Union[DataLoader, pd.DataFrame, TimeSeriesDataSet]): data

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -816,7 +816,10 @@ class BaseModel(LightningModule):
                 if isinstance(v0, torch.Tensor):
                     output_cat[name] = torch.cat([out[name] for out in output], dim=0)
                 elif isinstance(v0, (tuple, list)) and len(v0) > 0 and isinstance(v0[0], torch.Tensor):
-                    output_cat[name] = [torch.cat(out[name], dim=0) for out in output]
+
+                    output_cat[name] = []
+                    for k in range(len(v0)):
+                        output_cat[name].append(torch.cat([out[name][k] for out in output], dim=0))
                 else:
                     try:
                         output_cat[name] = np.concatenate([out[name] for out in output], axis=0)
@@ -830,7 +833,18 @@ class BaseModel(LightningModule):
         if return_x:
             x_cat = {}
             for name in x_list[0].keys():
-                x_cat[name] = torch.cat([x[name] for x in x_list], dim=0)
+                v0 = x_list[0][name]
+                if isinstance(v0, torch.Tensor):
+                    x_cat[name] = torch.cat([out[name] for out in x_list], dim=0)
+                elif isinstance(v0, (tuple, list)) and len(v0) > 0 and isinstance(v0[0], torch.Tensor):
+                    x_cat[name] = []
+                    for k in range(len(v0)):
+                        x_cat[name].append(torch.cat([out[name][k] for out in x_list], dim=0))
+                else:
+                    try:
+                        x_cat[name] = np.concatenate([out[name] for out in x_list], axis=0)
+                    except ValueError:
+                        x_cat[name] = [out[name] for out in x_list]
             x_cat = x_cat
             output.append(x_cat)
         if return_index:


### PR DESCRIPTION
- Handling multi-target prediction case with return_x=True.
- Concatenation of multi-target prediction output by target instead of batch. (little bug fix)