### PR TITLE
Make tuning trainer kwargs overwritable

### DIFF
--- a/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
@@ -129,8 +129,8 @@ def optimize_hyperparameters(
         learning_rate_callback = LearningRateMonitor()
         logger = TensorBoardLogger(log_dir, name="optuna", version=trial.number)
         gradient_clip_val = trial.suggest_loguniform("gradient_clip_val", *gradient_clip_val_range)
-        trainer_kwargs.setdefault("gpus", [0] if torch.cuda.is_available() else None)
-        trainer = pl.Trainer(
+        default_trainer_kwargs = dict(
+            gpus=[0] if torch.cuda.is_available() else None,
             max_epochs=max_epochs,
             gradient_clip_val=gradient_clip_val,
             callbacks=[
@@ -142,7 +142,10 @@ def optimize_hyperparameters(
             logger=logger,
             progress_bar_refresh_rate=[0, 1][optuna_verbose < optuna.logging.INFO],
             weights_summary=[None, "top"][optuna_verbose < optuna.logging.INFO],
-            **trainer_kwargs,
+        )
+        default_trainer_kwargs.update(trainer_kwargs)
+        trainer = pl.Trainer(
+            **default_trainer_kwargs,
         )
 
         # create model

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -215,7 +215,12 @@ def test_hyperparameter_optimization_integration(dataloaders_with_covariates, tm
             max_epochs=1,
             n_trials=3,
             log_dir=tmp_path,
-            trainer_kwargs=dict(fast_dev_run=True, limit_train_batches=5),
+            trainer_kwargs=dict(
+                fast_dev_run=True,
+                limit_train_batches=5,
+                # overwrite default trainer kwargs
+                progress_bar_refresh_rate=20,
+            ),
             use_learning_rate_finder=use_learning_rate_finder,
         )
     finally:


### PR DESCRIPTION
### Description

This PR fixes #299 

### Rationale

Overwriting default kwargs is sometimes useful, e.g. disabling logging or setting `progress_bar_refresh_rate>=20` on colab.

### Checklist

- [x] Linked issues (if existing)
- [x] This is a minor change <del>Amended changelog for large changes (and added myself there as contributor)</del>
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
