### PR TITLE
Add back link to github to docs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,12 +4,23 @@ on:
     types:
       - completed
 jobs:
-  automerge:
+  autoapprove:
+    name: Auto Approve a PR by dependabot
     runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/auto-approve-action@v2.0.0
+      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+  automerge:
+    name: Auto merge after successful checks
+    runs-on: ubuntu-latest
+    needs: autoapprove
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.13.0"
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: "dependencies"
-          MERGE_FILTER_AUTHOR: "dependabot-preview"
+          MERGE_LABELS: dependencies
+          MERGE_METHOD: rebase

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -12,6 +12,10 @@ h6,
 .navbar-nav > .active > a.nav-link {
   color: #ee4c2c !important;
 }
+a.nav-link[href="https://github.com/jdb78/pytorch-forecasting"]
+{
+  color: #ee4c2c !important;
+}
 
 code {
   color: #d14 !important;

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,6 +59,7 @@ The :ref:`Tutorials <tutorials>` section provides guidance on how to use models 
    contribute
    api
    CHANGELOG
+   GitHub <https://github.com/jdb78/pytorch-forecasting>
 
 
 Indices and tables


### PR DESCRIPTION
### Description

This PR adds back a link to github on the docs

### Checklist

- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
