### PR TITLE
Fix initialization of tft with correct order of arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v0.9.1 UNRELEASED
+
+### Fixed
+
+- Initialization of TemporalFusionTransformer with multiple targets but loss for only one target (#550)
+
 ## v0.9.0 Simplified API (04/06/2021)
 
 ### Breaking changes

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -1,6 +1,7 @@
 """
 The temporal fusion transformer is a powerful predictive model for forecasting timeseries
 """
+from copy import copy
 from typing import Dict, List, Tuple, Union
 
 from matplotlib import pyplot as plt
@@ -341,11 +342,10 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             TemporalFusionTransformer
         """
         # add maximum encoder length
-        new_kwargs = dict(max_encoder_length=dataset.max_encoder_length)
-        new_kwargs.update(cls.deduce_default_output_parameters(dataset, kwargs, QuantileLoss()))
-
         # update defaults
-        new_kwargs.update(kwargs)
+        new_kwargs = copy(kwargs)
+        new_kwargs["max_encoder_length"] = dataset.max_encoder_length
+        new_kwargs.update(cls.deduce_default_output_parameters(dataset, kwargs, QuantileLoss()))
 
         # create class and return
         return super().from_dataset(

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -41,6 +41,7 @@ def data_with_covariates():
         "music_fest",
     ]
     data[special_days] = data[special_days].apply(lambda x: x.map({0: "", 1: x.name})).astype("category")
+    data = data.astype(dict(industry_volume=float))
 
     return data
 
@@ -109,6 +110,7 @@ def make_dataloaders(data_with_covariates, **kwargs):
         dict(target_normalizer=GroupNormalizer(groups=["agency", "sku"], transformation="softplus", center=False)),
         dict(target="agency"),
         # test multiple targets
+        dict(target=["industry_volume", "volume"]),
         dict(target=["agency", "volume"]),
         dict(target=["agency", "volume"], min_encoder_length=1, min_prediction_length=1),
         dict(target=["agency", "volume"], weight="volume"),


### PR DESCRIPTION
### Description

This PR fixes an issue when the passed loss function is not correctly modified for the TFT.

### Checklist

- [x] Linked issues (if existing)
- [x] Amended changelog for large changes (and added myself there as contributor)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
