### PR TITLE
Fixed typo in BaseModel doc string

### DIFF
--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -623,7 +623,7 @@ class BaseModel(LightningModule):
             x (Dict[str, torch.Tensor]): x as passed to the network by the dataloader
             out (Dict[str, torch.Tensor]): output of the network
             batch_idx (int): current batch index
-            **kwargs: paramters to pass to ``pot_prediction``
+            **kwargs: paramters to pass to ``plot_prediction``
         """
         # log single prediction figure
         if (batch_idx % self.log_interval == 0 or self.log_interval < 1.0) and self.log_interval > 0:


### PR DESCRIPTION
### Description

This PR fixes the typo ```pot_prediction -> plot_prediction``` present in the ```log_prediction()``` function in the definition of the class ```BaseModel```.
