### PR TITLE
Added pruner option to TFT optimize_hyperparameters-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@
 - Use target name instead of target number for logging metrics (#588)
 - Optimizer can be initialized by passing string, class or function (#602)
 - Add support for multiple outputs in Baseline model (#603)
+- Added Optuna pruner as optional parameter in `TemporalFusionTransformer.optimize_hyperparameters` (#619)
+
 
 ### Fixed
 
 - Initialization of TemporalFusionTransformer with multiple targets but loss for only one target (#550)
 - Added missing transformation of prediction for MLP (#602)
+
+### Contributors
+
+- jdb78
+- TKlerx
 
 ## v0.9.0 Simplified API (04/06/2021)
 

--- a/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
@@ -54,6 +54,7 @@ def optimize_hyperparameters(
     log_dir: str = "lightning_logs",
     study: optuna.Study = None,
     verbose: Union[int, bool] = None,
+    pruner: optuna.pruners.BasePruner = optuna.pruners.SuccessiveHalvingPruner(),
     **kwargs,
 ) -> optuna.Study:
     """
@@ -92,6 +93,8 @@ def optimize_hyperparameters(
             * 1 or True: log pruning events.
             * 2: optuna logging level at debug level.
             Defaults to None.
+        pruner (optuna.pruners.BasePruner, optional): The optuna pruner to use.
+            Defaults to optuna.pruners.SuccessiveHalvingPruner().
 
         **kwargs: Additional arguments for the :py:class:`~TemporalFusionTransformer`.
 
@@ -209,7 +212,6 @@ def optimize_hyperparameters(
         return metrics_callback.metrics[-1]["val_loss"].item()
 
     # setup optuna and run
-    pruner = optuna.pruners.SuccessiveHalvingPruner()
     if study is None:
         study = optuna.create_study(direction="minimize", pruner=pruner)
     study.optimize(objective, n_trials=n_trials, timeout=timeout)


### PR DESCRIPTION
### Description

Add possibility to change pruner for `optimize_hyperparameters` in `TFT` according to #589 

### Checklist

- [X] Linked issues (if existing)
- [X] Amended changelog for large changes (and added myself there as contributor): Not a big change :)
- [x] Added/modified tests: Not necessary, I guess.
- [X] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`
