### PR TITLE
fix: pandas version <1.3.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ cloudpickle
 torch>=1.6
 optuna>=2.0
 scipy
-pandas>=1.0
+pandas>=1.0,<=1.2.5
 scikit-learn>0.23
 matplotlib
 statsmodels


### PR DESCRIPTION

### Description

With pandas version 1.3.x, there will be AttributeError: 'functools.partial' object has no attribute '__name__'.
Tested that pandas version should be 1.2.x

### Checklist

- [x] Linked issues https://github.com/jdb78/pytorch-forecasting/issues/610
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
