### PR TITLE
Typo in argument of TimeSeriesDataSet

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -71,7 +71,7 @@ Example
     data = ...
 
     # define dataset
-    max_encode_length = 36
+    max_encoder_length = 36
     max_prediction_length = 6
     training_cutoff = "YYYY-MM-DD"  # day for cutoff
 
@@ -81,7 +81,7 @@ Example
         target= ...,
         # weight="weight",
         group_ids=[ ... ],
-        max_encode_length=max_encode_length,
+        max_encoder_length=max_encoder_length,
         max_prediction_length=max_prediction_length,
         static_categoricals=[ ... ],
         static_reals=[ ... ],


### PR DESCRIPTION
### Description

Typo in argument of TimeSeriesDataSet. I was studying pytorch forecasting with getting-started documents, and I found some little typo.. 

### Checklist

- [x] Linked issues (if existing)
- [x] Amended changelog for large changes (and added myself there as contributor)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

