### PR TITLE
- add fitted_ attribute to MultiNormalizer when fit is called

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -783,6 +783,7 @@ class MultiNormalizer(TorchNormalizer):
             else:
                 normalizer.fit(y[:, idx])
 
+        self.fitted_ = True
         return self
 
     def __getitem__(self, idx: int):


### PR DESCRIPTION
### Description

This PR solves issue #680 

### Checklist

- [x] Linked issues (if existing) #680 
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`
