### PR TITLE
Fix inattention mutation to `x_cont`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v0.9.2 UNRELEASED
+
+### Added
+
+### Fixed
+
+- Fix inattention mutation to `x_cont`. 
+
+### Contributors
+
+- eavae
+
 ## v0.9.1 Maintenance Release (26/09/2021)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- Fix inattention mutation to `x_cont`. 
+- Fix inattention mutation to `x_cont`.
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- Fix inattention mutation to `x_cont`.
+- Fix inattention mutation to `x_cont` (#732).
 
 ### Contributors
 

--- a/pytorch_forecasting/models/deepar/__init__.py
+++ b/pytorch_forecasting/models/deepar/__init__.py
@@ -204,7 +204,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
             input_vector = flat_embeddings
 
         if len(self.reals) > 0:
-            input_vector = x_cont
+            input_vector = x_cont.clone()
 
         if len(self.reals) > 0 and len(self.categoricals) > 0:
             input_vector = torch.cat([x_cont, flat_embeddings], dim=-1)

--- a/pytorch_forecasting/models/rnn/__init__.py
+++ b/pytorch_forecasting/models/rnn/__init__.py
@@ -174,7 +174,7 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
             input_vector = flat_embeddings
 
         if len(self.reals) > 0:
-            input_vector = x_cont
+            input_vector = x_cont.clone()
 
         if len(self.reals) > 0 and len(self.categoricals) > 0:
             input_vector = torch.cat([x_cont, flat_embeddings], dim=-1)


### PR DESCRIPTION
### Description

This PR fixed an issue about inattention mutation with `x_cont` that caused original data changed.

The mutation happened here:

```python
input_vector[..., self.target_positions] = torch.roll(
    input_vector[..., self.target_positions], shifts=1, dims=1
)
```

It caused `x_cont` changed. And the changes keep exists from `encode` to `decode`. So, the shift happen twice. 

### Checklist

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
