### PR TITLE
Update metrics.py

### DIFF
--- a/pytorch_forecasting/metrics.py
+++ b/pytorch_forecasting/metrics.py
@@ -40,7 +40,7 @@ class Metric(LightningMetric):
         self.name = name
         super().__init__()
 
-    def update(y_pred: torch.Tensor, y_actual: torch.Tensor):
+    def update(self, y_pred: torch.Tensor, y_actual: torch.Tensor):
         raise NotImplementedError()
 
     def compute(self) -> torch.Tensor:


### PR DESCRIPTION
Fixing the signature for the base metric class

### Description

This PR just adds a tiny `self` argument to the base `Metric.update` method. It's still getting overridden in all the other metrics, but still, IDEs give the annoying warning for overriding the base signature.