### PR TITLE
Fix condition for UserWarning (issue #635)

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -114,7 +114,7 @@ class NaNLabelEncoder(BaseEstimator, TransformerMixin):
         """
         if self.add_nan:
             if self.warn:
-                cond = ~np.isin(y, self.classes_)
+                cond = np.array([item not in self.classes_ for item in y])
                 if cond.any():
                     warnings.warn(
                         f"Found {np.unique(np.asarray(y)[cond]).size} unknown classes which were set to NaN",


### PR DESCRIPTION
### Description

This PR addresses #635. As the issue author mentioned, the [current](https://github.com/jdb78/pytorch-forecasting/blob/master/pytorch_forecasting/data/encoders.py#L117) `np.isin` condition doesn't work right and yields to raising UserWarning all the time, at least for `y` being `pandas.Series` object (in my testing).

Maybe this fix is a bit clanky in terms of performance, so would be glad to hear any suggestions!