### PR TITLE
Fix pytorch warning when converting lists of ndarrays

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1654,7 +1654,7 @@ class TimeSeriesDataSet(Dataset):
                     scale = torch.tensor([batch[0]["target_scale"][idx] for batch in batches], dtype=torch.float)
                 target_scale.append(scale)
         else:  # convert to tensor
-            target_scale = torch.tensor([batch[0]["target_scale"] for batch in batches], dtype=torch.float)
+            target_scale = torch.from_numpy(np.array([batch[0]["target_scale"] for batch in batches], dtype=np.float))
 
         # target and weight
         if isinstance(batches[0][1][0], (tuple, list)):


### PR DESCRIPTION
### Description

This PR removes a new pytorch warning that occurs when converting a list of ndarrays to a tensor, and which happens on every batch if target_scale is a ndarray.

Full warning here:
```UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at  ../torch/csrc/utils/tensor_new.cpp:201.)```

The change shouldn't have any negative effect if `[batch[0]["target_scale"]` isn't an `ndarray`.

### Checklist

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
