### PR TITLE
Ensure `TorchNormalizer` transformation output type matches input type

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -355,10 +355,13 @@ class TorchNormalizer(BaseEstimator, TransformerMixin):
                 self.scale_ = torch.std(y_scale, dim=-1) + self.eps
             elif isinstance(y_center, np.ndarray):
                 self.center_ = np.mean(y_center, axis=-1)
-                self.scale_ = (np.std(y_scale, axis=-1) + self.eps).astype(y_scale.dtype)
+                self.scale_ = np.std(y_scale, axis=-1) + self.eps
             else:
                 self.center_ = np.mean(y_center)
-                self.scale_ = (np.std(y_scale) + self.eps).astype(y_scale.dtype)
+                self.scale_ = np.std(y_scale) + self.eps
+            # correct numpy scalar dtype promotion, e.g. fix type from `np.float32(0.0) + 1e-8` gives `np.float64(1e-8)`
+            if not torch.is_tensor(self.scale_) and np.isscalar(self.scale_):
+                self.scale_ = self.scale_.astype(y_scale.dtype)
 
         elif self.method == "robust":
             if isinstance(y_center, torch.Tensor):

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -355,10 +355,10 @@ class TorchNormalizer(BaseEstimator, TransformerMixin):
                 self.scale_ = torch.std(y_scale, dim=-1) + self.eps
             elif isinstance(y_center, np.ndarray):
                 self.center_ = np.mean(y_center, axis=-1)
-                self.scale_ = np.std(y_scale, axis=-1) + self.eps
+                self.scale_ = (np.std(y_scale, axis=-1) + self.eps).astype(y_scale.dtype)
             else:
                 self.center_ = np.mean(y_center)
-                self.scale_ = np.std(y_scale) + self.eps
+                self.scale_ = (np.std(y_scale) + self.eps).astype(y_scale.dtype)
 
         elif self.method == "robust":
             if isinstance(y_center, torch.Tensor):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -620,3 +620,11 @@ def test_filter_data(test_dataset, agency, first_prediction_idx, should_raise):
             index = test_dataset.x_to_index(x)
             assert (index["agency"] == agency).all(), "Agency filter has failed"
             assert index["time_idx"].min() == first_prediction_idx, "First prediction filter has failed"
+
+
+def test_TorchNormalizer_dtype_consistency():
+    """Ensures that even for float64 `target_scale`, the transformation will not change the prediction dtype."""
+    parameters = torch.tensor([[[366.4587]]])
+    target_scale = torch.tensor([[427875.7500, 80367.4766]], dtype=torch.float64)
+    assert TorchNormalizer()(dict(prediction=parameters, target_scale=target_scale)).dtype == torch.float32
+    assert TorchNormalizer().transform(parameters, target_scale=target_scale).dtype == torch.float32


### PR DESCRIPTION
### Description

Addresses #574 by avoiding type promotion from float32 -> float64 during `TorchNormalizer` transformations.

### Checklist

- [x] Linked issues (if existing)
- ~[] Amended changelog for large changes (and added myself there as contributor)~ --> just a bugfix here
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding! :heavy_check_mark: 
