### PR TITLE
Implement logger adapter to handle different loggers (TensorBoard and Wandb for now)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -293,7 +293,7 @@ unicode_backport = ["unicodedata2"]
 name = "click"
 version = "8.0.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -385,6 +385,18 @@ python-versions = "*"
 test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
+name = "configparser"
+version = "5.2.0"
+description = "Updated configparser from Python 3.8 for Python 2.6+."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "types-backports", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
+[[package]]
 name = "coverage"
 version = "6.2"
 description = "Code coverage measurement for Python"
@@ -437,6 +449,17 @@ description = "Distribution utilities"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "docker-pycreds"
+version = "0.4.0"
+description = "Python bindings for the docker credentials store API"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.4.0"
 
 [[package]]
 name = "docutils"
@@ -561,6 +584,29 @@ description = "Clean single-source support for Python 3 and 2"
 category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "gitdb"
+version = "4.0.9"
+description = "Git Object Database"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.24"
+description = "GitPython is a python library used to interact with Git repositories"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.10\""}
 
 [[package]]
 name = "google-auth"
@@ -1225,6 +1271,14 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
+name = "pathtools"
+version = "0.1.2"
+description = "File system general utilities"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "patsy"
 version = "0.5.2"
 description = "A Python package for describing statistical models and for building design matrices."
@@ -1358,6 +1412,20 @@ wcwidth = "*"
 tests = ["pytest", "pytest-cov", "pytest-lazy-fixture"]
 
 [[package]]
+name = "promise"
+version = "2.3"
+description = "Promises/A+ implementation for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+test = ["pytest (>=2.7.3)", "pytest-cov", "coveralls", "futures", "pytest-benchmark", "mock"]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.24"
 description = "Library for building powerful interactive command lines in Python"
@@ -1375,6 +1443,17 @@ description = "Protocol Buffers"
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "psutil"
+version = "5.9.0"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
 
 [[package]]
 name = "ptyprocess"
@@ -1808,6 +1887,35 @@ python-versions = ">=3.7"
 numpy = ">=1.16.5"
 
 [[package]]
+name = "sentry-sdk"
+version = "1.5.1"
+description = "Python client for Sentry (https://sentry.io)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.10.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.5)"]
+beam = ["apache-beam (>=2.12)"]
+bottle = ["bottle (>=0.12.13)"]
+celery = ["celery (>=3)"]
+chalice = ["chalice (>=1.16.0)"]
+django = ["django (>=1.8)"]
+falcon = ["falcon (>=1.4)"]
+flask = ["flask (>=0.11)", "blinker (>=1.1)"]
+httpx = ["httpx (>=0.16.0)"]
+pure_eval = ["pure-eval", "executing", "asttokens"]
+pyspark = ["pyspark (>=2.4.4)"]
+rq = ["rq (>=0.6)"]
+sanic = ["sanic (>=0.8)"]
+sqlalchemy = ["sqlalchemy (>=1.2)"]
+tornado = ["tornado (>=5)"]
+
+[[package]]
 name = "setuptools-scm"
 version = "6.3.2"
 description = "the blessed package to manage your versions by scm tags"
@@ -1823,12 +1931,28 @@ tomli = ">=1.0.0"
 toml = ["setuptools (>=42)", "tomli (>=1.0.0)"]
 
 [[package]]
+name = "shortuuid"
+version = "1.0.8"
+description = "A generator library for concise, unambiguous and URL-safe UUIDs."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "smmap"
+version = "5.0.0"
+description = "A pure Python implementation of a sliding window memory map manager"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "snowballstemmer"
@@ -2013,6 +2137,14 @@ importlib-metadata = {version = ">=1.7.0", markers = "python_version < \"3.8\""}
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
+name = "subprocess32"
+version = "3.5.4"
+description = "A backport of the subprocess module from Python 3 for use on 2.x."
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4"
+
+[[package]]
 name = "tensorboard"
 version = "2.7.0"
 description = "TensorBoard lets you watch Tensors Flow"
@@ -2053,7 +2185,7 @@ python-versions = "*"
 name = "termcolor"
 version = "1.1.0"
 description = "ANSII Color formatting for output in terminal."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -2219,6 +2351,42 @@ docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sp
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
 
 [[package]]
+name = "wandb"
+version = "0.12.9"
+description = "A CLI and library for interacting with the Weights and Biases API."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+Click = ">=7.0,<8.0.0 || >8.0.0"
+configparser = ">=3.8.1"
+docker-pycreds = ">=0.4.0"
+GitPython = ">=1.0.0"
+pathtools = "*"
+promise = ">=2.0,<3"
+protobuf = ">=3.12.0"
+psutil = ">=5.0.0"
+python-dateutil = ">=2.6.1"
+PyYAML = "*"
+requests = ">=2.0.0,<3"
+sentry-sdk = ">=1.0.0"
+shortuuid = ">=0.5.0"
+six = ">=1.13.0"
+subprocess32 = ">=3.5.3"
+yaspin = ">=1.0.0"
+
+[package.extras]
+aws = ["boto3"]
+gcp = ["google-cloud-storage"]
+grpc = ["grpcio (>=1.27.2)", "setproctitle"]
+kubeflow = ["kubernetes", "minio", "google-cloud-storage", "sh"]
+launch = ["jupyter-repo2docker", "nbconvert", "chardet", "iso8601", "typing-extensions", "yaspin"]
+media = ["numpy", "moviepy", "pillow", "bokeh", "soundfile", "plotly", "rdkit-pypi"]
+service = ["setproctitle"]
+sweeps = ["numpy (>=1.15,<1.21)", "scipy (>=1.5.4)", "pyyaml", "scikit-learn (==0.24.1)", "jsonschema (>=3.2.0)", "jsonref (>=0.2)", "pydantic (>=1.8.2)"]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -2267,6 +2435,17 @@ multidict = ">=4.0"
 typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [[package]]
+name = "yaspin"
+version = "2.1.0"
+description = "Yet Another Terminal Spinner"
+category = "main"
+optional = false
+python-versions = ">=3.6.2,<4.0.0"
+
+[package.dependencies]
+termcolor = ">=1.1.0,<2.0.0"
+
+[[package]]
 name = "zipp"
 version = "3.6.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -2284,7 +2463,7 @@ github-actions = ["pytest-github-actions-annotate-failures"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "fe1e113f8d2c75b7d01190502517e3ae3423ab2f8cef913629c908f33d294e37"
+content-hash = "888859f20312d05fe9e7e88779d99693aeb1a4216c691bcbcf6fb062668b241d"
 
 [metadata.files]
 absl-py = [
@@ -2529,6 +2708,10 @@ commonmark = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
     {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
+configparser = [
+    {file = "configparser-5.2.0-py3-none-any.whl", hash = "sha256:e8b39238fb6f0153a069aa253d349467c3c4737934f253ef6abac5fe0eca1e5d"},
+    {file = "configparser-5.2.0.tar.gz", hash = "sha256:1b35798fdf1713f1c3139016cfcbc461f09edbf099d1fb658d4b7479fcaa3daa"},
+]
 coverage = [
     {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
     {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
@@ -2616,6 +2799,10 @@ defusedxml = [
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+]
+docker-pycreds = [
+    {file = "docker-pycreds-0.4.0.tar.gz", hash = "sha256:6ce3270bcaf404cc4c3e27e4b6c70d3521deae82fb508767870fdbf772d584d4"},
+    {file = "docker_pycreds-0.4.0-py2.py3-none-any.whl", hash = "sha256:7266112468627868005106ec19cd0d722702d2b7d5912a28e19b826c3d37af49"},
 ]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
@@ -2721,6 +2908,14 @@ fsspec = [
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
+gitdb = [
+    {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
+    {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
+]
+gitpython = [
+    {file = "GitPython-3.1.24-py3-none-any.whl", hash = "sha256:dc0a7f2f697657acc8d7f89033e8b1ea94dd90356b2983bca89dc8d2ab3cc647"},
+    {file = "GitPython-3.1.24.tar.gz", hash = "sha256:df83fdf5e684fef7c6ee2c02fc68a5ceb7e7e759d08b694088d0cacb4eba59e5"},
 ]
 google-auth = [
     {file = "google-auth-2.3.3.tar.gz", hash = "sha256:d83570a664c10b97a1dc6f8df87e5fdfff012f48f62be131e449c20dfc32630e"},
@@ -3327,6 +3522,9 @@ pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
+pathtools = [
+    {file = "pathtools-0.1.2.tar.gz", hash = "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"},
+]
 patsy = [
     {file = "patsy-0.5.2-py2.py3-none-any.whl", hash = "sha256:cc80955ae8c13a7e7c4051eda7b277c8f909f50bc7d73e124bc38e2ee3d95041"},
     {file = "patsy-0.5.2.tar.gz", hash = "sha256:5053de7804676aba62783dbb0f23a2b3d74e35e5bfa238b88b7cbf148a38b69d"},
@@ -3410,6 +3608,9 @@ prettytable = [
     {file = "prettytable-2.4.0-py3-none-any.whl", hash = "sha256:2492f29e8686bdbcce815a568bff74cb71cbb704747c3abb9c9c6cfe25f985a2"},
     {file = "prettytable-2.4.0.tar.gz", hash = "sha256:18e56447f636b447096977d468849c1e2d3cfa0af8e7b5acfcf83a64790c0aca"},
 ]
+promise = [
+    {file = "promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"},
+]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.24-py3-none-any.whl", hash = "sha256:e56f2ff799bacecd3e88165b1e2f5ebf9bcd59e80e06d395fa0cc4b8bd7bb506"},
     {file = "prompt_toolkit-3.0.24.tar.gz", hash = "sha256:1bb05628c7d87b645974a1bad3f17612be0c29fa39af9f7688030163f680bad6"},
@@ -3439,6 +3640,35 @@ protobuf = [
     {file = "protobuf-3.19.1-cp39-cp39-win_amd64.whl", hash = "sha256:77d2fadcf369b3f22859ab25bd12bb8e98fb11e05d9ff9b7cd45b711c719c002"},
     {file = "protobuf-3.19.1-py2.py3-none-any.whl", hash = "sha256:e813b1c9006b6399308e917ac5d298f345d95bb31f46f02b60cd92970a9afa17"},
     {file = "protobuf-3.19.1.tar.gz", hash = "sha256:62a8e4baa9cb9e064eb62d1002eca820857ab2138440cb4b3ea4243830f94ca7"},
+]
+psutil = [
+    {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b"},
+    {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:7336292a13a80eb93c21f36bde4328aa748a04b68c13d01dfddd67fc13fd0618"},
+    {file = "psutil-5.9.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:cb8d10461c1ceee0c25a64f2dd54872b70b89c26419e147a05a10b753ad36ec2"},
+    {file = "psutil-5.9.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:7641300de73e4909e5d148e90cc3142fb890079e1525a840cf0dfd39195239fd"},
+    {file = "psutil-5.9.0-cp27-none-win32.whl", hash = "sha256:ea42d747c5f71b5ccaa6897b216a7dadb9f52c72a0fe2b872ef7d3e1eacf3ba3"},
+    {file = "psutil-5.9.0-cp27-none-win_amd64.whl", hash = "sha256:ef216cc9feb60634bda2f341a9559ac594e2eeaadd0ba187a4c2eb5b5d40b91c"},
+    {file = "psutil-5.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90a58b9fcae2dbfe4ba852b57bd4a1dded6b990a33d6428c7614b7d48eccb492"},
+    {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff0d41f8b3e9ebb6b6110057e40019a432e96aae2008951121ba4e56040b84f3"},
+    {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2"},
+    {file = "psutil-5.9.0-cp310-cp310-win32.whl", hash = "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d"},
+    {file = "psutil-5.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b"},
+    {file = "psutil-5.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0"},
+    {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce"},
+    {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5"},
+    {file = "psutil-5.9.0-cp37-cp37m-win32.whl", hash = "sha256:df2c8bd48fb83a8408c8390b143c6a6fa10cb1a674ca664954de193fdcab36a9"},
+    {file = "psutil-5.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1d7b433519b9a38192dfda962dd8f44446668c009833e1429a52424624f408b4"},
+    {file = "psutil-5.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c3400cae15bdb449d518545cbd5b649117de54e3596ded84aacabfbb3297ead2"},
+    {file = "psutil-5.9.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2237f35c4bbae932ee98902a08050a27821f8f6dfa880a47195e5993af4702d"},
+    {file = "psutil-5.9.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1070a9b287846a21a5d572d6dddd369517510b68710fca56b0e9e02fd24bed9a"},
+    {file = "psutil-5.9.0-cp38-cp38-win32.whl", hash = "sha256:76cebf84aac1d6da5b63df11fe0d377b46b7b500d892284068bacccf12f20666"},
+    {file = "psutil-5.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:3151a58f0fbd8942ba94f7c31c7e6b310d2989f4da74fcbf28b934374e9bf841"},
+    {file = "psutil-5.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:539e429da49c5d27d5a58e3563886057f8fc3868a5547b4f1876d9c0f007bccf"},
+    {file = "psutil-5.9.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58c7d923dc209225600aec73aa2c4ae8ea33b1ab31bc11ef8a5933b027476f07"},
+    {file = "psutil-5.9.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3611e87eea393f779a35b192b46a164b1d01167c9d323dda9b1e527ea69d697d"},
+    {file = "psutil-5.9.0-cp39-cp39-win32.whl", hash = "sha256:4e2fb92e3aeae3ec3b7b66c528981fd327fb93fd906a77215200404444ec1845"},
+    {file = "psutil-5.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:7d190ee2eaef7831163f254dc58f6d2e2a22e27382b936aab51c835fc080c3d3"},
+    {file = "psutil-5.9.0.tar.gz", hash = "sha256:869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -3790,13 +4020,25 @@ scipy = [
     {file = "scipy-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:a5193a098ae9f29af283dcf0041f762601faf2e595c0db1da929875b7570353f"},
     {file = "scipy-1.6.1.tar.gz", hash = "sha256:c4fceb864890b6168e79b0e714c585dbe2fd4222768ee90bc1aa0f8218691b11"},
 ]
+sentry-sdk = [
+    {file = "sentry-sdk-1.5.1.tar.gz", hash = "sha256:2a1757d6611e4bec7d672c2b7ef45afef79fed201d064f53994753303944f5a8"},
+    {file = "sentry_sdk-1.5.1-py2.py3-none-any.whl", hash = "sha256:e4cb107e305b2c1b919414775fa73a9997f996447417d22b98e7610ded1e9eb5"},
+]
 setuptools-scm = [
     {file = "setuptools_scm-6.3.2-py3-none-any.whl", hash = "sha256:4c64444b1d49c4063ae60bfe1680f611c8b13833d556fd1d6050c0023162a119"},
     {file = "setuptools_scm-6.3.2.tar.gz", hash = "sha256:a49aa8081eeb3514eb9728fa5040f2eaa962d6c6f4ec9c32f6c1fba88f88a0f2"},
 ]
+shortuuid = [
+    {file = "shortuuid-1.0.8-py3-none-any.whl", hash = "sha256:44a7a86bcf24dbaba2e626cf80c779926b7c3a0d31a3a013e0d3cd1077707d23"},
+    {file = "shortuuid-1.0.8.tar.gz", hash = "sha256:9435e87e5a64f3b92f7110c81f989a3b7bdb9358e22d2359829167da476cfc23"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+smmap = [
+    {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
+    {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
@@ -3895,6 +4137,11 @@ statsmodels = [
 stevedore = [
     {file = "stevedore-3.5.0-py3-none-any.whl", hash = "sha256:a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c"},
     {file = "stevedore-3.5.0.tar.gz", hash = "sha256:f40253887d8712eaa2bb0ea3830374416736dc8ec0e22f5a65092c1174c44335"},
+]
+subprocess32 = [
+    {file = "subprocess32-3.5.4-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:88e37c1aac5388df41cc8a8456bb49ebffd321a3ad4d70358e3518176de3a56b"},
+    {file = "subprocess32-3.5.4-cp27-cp27mu-manylinux2014_x86_64.whl", hash = "sha256:e45d985aef903c5b7444d34350b05da91a9e0ea015415ab45a21212786c649d0"},
+    {file = "subprocess32-3.5.4.tar.gz", hash = "sha256:eb2937c80497978d181efa1b839ec2d9622cf9600a039a79d0e108d1f9aec79d"},
 ]
 tensorboard = [
     {file = "tensorboard-2.7.0-py3-none-any.whl", hash = "sha256:239f78a4a8dff200ce585a030c787773a8c1184d5c159252f5f85bac4e3c3b38"},
@@ -4049,6 +4296,10 @@ virtualenv = [
     {file = "virtualenv-20.10.0-py2.py3-none-any.whl", hash = "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814"},
     {file = "virtualenv-20.10.0.tar.gz", hash = "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"},
 ]
+wandb = [
+    {file = "wandb-0.12.9-py2.py3-none-any.whl", hash = "sha256:32b24334c6f59ed238481c4cb3cffa2b951749fd62aaf061c6cac666bb0f30ac"},
+    {file = "wandb-0.12.9.tar.gz", hash = "sha256:2aad811ff0151be62ffdf49d5fcd027c222d2861b5f459134e778d1a7eee6a1b"},
+]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
@@ -4187,6 +4438,10 @@ yarl = [
     {file = "yarl-1.7.2-cp39-cp39-win32.whl", hash = "sha256:1edc172dcca3f11b38a9d5c7505c83c1913c0addc99cd28e993efeaafdfaa18d"},
     {file = "yarl-1.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:797c2c412b04403d2da075fb93c123df35239cd7b4cc4e0cd9e5839b73f52c58"},
     {file = "yarl-1.7.2.tar.gz", hash = "sha256:45399b46d60c253327a460e99856752009fcee5f5d3c80b2f7c0cae1c38d56dd"},
+]
+yaspin = [
+    {file = "yaspin-2.1.0-py3-none-any.whl", hash = "sha256:d574cbfaf0a349df466c91f7f81b22460ae5ebb15ecb8bf9411d6049923aee8d"},
+    {file = "yaspin-2.1.0.tar.gz", hash = "sha256:c8d34eca9fda3f4dfbe59f57f3cf0f3641af3eefbf1544fbeb9b3bacf82c580a"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ matplotlib = "*"
 statsmodels = "*"
 
 pytest-github-actions-annotate-failures = {version = "*", optional = true}
+wandb = "^0.12.9"
 
 [tool.poetry.dev-dependencies]
 # checks and make tools

--- a/pytorch_forecasting/loggers/__init__.py
+++ b/pytorch_forecasting/loggers/__init__.py
@@ -1,8 +1,8 @@
 """
 Forecasting loggers for timeseries forecasting.
 """
-
+from pytorch_forecasting.loggers.base_logger import ForecastingLoggerBase
 from pytorch_forecasting.loggers.tensorboard_logger import ForecastingTensorBoardLogger
 from pytorch_forecasting.loggers.wandb_logger import ForecastingWandbLogger
 
-__all__ = ["ForecastingTensorBoardLogger", "ForecastingWandbLogger"]
+__all__ = ["ForecastingLoggerBase", "ForecastingTensorBoardLogger", "ForecastingWandbLogger"]

--- a/pytorch_forecasting/loggers/__init__.py
+++ b/pytorch_forecasting/loggers/__init__.py
@@ -1,0 +1,9 @@
+"""
+Forecasting loggers for timeseries forecasting.
+"""
+
+from pytorch_forecasting.loggers.wandb_logger import ForecastingWandbLogger
+
+from pytorch_forecasting.loggers.tensorboard_logger import ForecastingTensorBoardLogger
+
+__all__ = ["ForecastingTensorBoardLogger", "ForecastingWandbLogger"]

--- a/pytorch_forecasting/loggers/__init__.py
+++ b/pytorch_forecasting/loggers/__init__.py
@@ -2,8 +2,7 @@
 Forecasting loggers for timeseries forecasting.
 """
 
-from pytorch_forecasting.loggers.wandb_logger import ForecastingWandbLogger
-
 from pytorch_forecasting.loggers.tensorboard_logger import ForecastingTensorBoardLogger
+from pytorch_forecasting.loggers.wandb_logger import ForecastingWandbLogger
 
 __all__ = ["ForecastingTensorBoardLogger", "ForecastingWandbLogger"]

--- a/pytorch_forecasting/loggers/base_logger.py
+++ b/pytorch_forecasting/loggers/base_logger.py
@@ -1,0 +1,21 @@
+from typing import Dict, List
+
+import torch
+from pytorch_lightning.loggers.base import LightningLoggerBase
+from matplotlib.figure import Figure
+
+from pytorch_forecasting import MultiEmbedding
+
+
+class ForecastingLoggerBase(LightningLoggerBase):
+    def __init__(self, *args, **kwargs):
+        super(ForecastingLoggerBase, self).__init__(*args, **kwargs)
+
+    def add_figure(self, caption: str, figure: Figure, step: int) -> None:
+        pass
+
+    def add_embeddings(self, input_embeddings: MultiEmbedding, embeddings_labels: Dict[str, List[str]], step: int) -> None:
+        pass
+
+    def log_gradient_flow(self, named_parameters: Dict[str, torch.Tensor], step: int) -> None:
+        pass

--- a/pytorch_forecasting/loggers/base_logger.py
+++ b/pytorch_forecasting/loggers/base_logger.py
@@ -1,8 +1,8 @@
 from typing import Dict, List
 
-import torch
-from pytorch_lightning.loggers.base import LightningLoggerBase
 from matplotlib.figure import Figure
+from pytorch_lightning.loggers.base import LightningLoggerBase
+import torch
 
 from pytorch_forecasting import MultiEmbedding
 
@@ -14,7 +14,9 @@ class ForecastingLoggerBase(LightningLoggerBase):
     def add_figure(self, caption: str, figure: Figure, step: int) -> None:
         pass
 
-    def add_embeddings(self, input_embeddings: MultiEmbedding, embeddings_labels: Dict[str, List[str]], step: int) -> None:
+    def add_embeddings(
+        self, input_embeddings: MultiEmbedding, embeddings_labels: Dict[str, List[str]], step: int
+    ) -> None:
         pass
 
     def log_gradient_flow(self, named_parameters: Dict[str, torch.Tensor], step: int) -> None:

--- a/pytorch_forecasting/loggers/tensorboard_logger/__init__.py
+++ b/pytorch_forecasting/loggers/tensorboard_logger/__init__.py
@@ -1,9 +1,9 @@
-from typing import List, Dict
+from typing import Dict, List
 
-import torch
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 from pytorch_lightning.loggers import TensorBoardLogger
+import torch
 
 from pytorch_forecasting import MultiEmbedding
 from pytorch_forecasting.loggers.base_logger import ForecastingLoggerBase

--- a/pytorch_forecasting/loggers/tensorboard_logger/__init__.py
+++ b/pytorch_forecasting/loggers/tensorboard_logger/__init__.py
@@ -29,8 +29,8 @@ class ForecastingTensorBoardLogger(TensorBoardLogger, ForecastingLoggerBase):
         for name, p in named_parameters:
             if p.grad is not None and p.requires_grad and "bias" not in name:
                 layers.append(name)
-                ave_grads.append(p.grad.abs().mean())
-                self.experiment.add_histogram(tag=name, values=p.grad, global_step=step)
+                ave_grads.append(p.grad.abs().mean().cpu())
+                self.experiment.add_histogram(tag=name, values=p.grad.cpu(), global_step=step)
         fig, ax = plt.subplots()
         ax.plot(ave_grads)
         ax.set_xlabel("Layers")

--- a/pytorch_forecasting/loggers/tensorboard_logger/__init__.py
+++ b/pytorch_forecasting/loggers/tensorboard_logger/__init__.py
@@ -1,0 +1,40 @@
+from typing import List, Dict
+
+import torch
+from matplotlib import pyplot as plt
+from matplotlib.figure import Figure
+from pytorch_lightning.loggers import TensorBoardLogger
+
+from pytorch_forecasting import MultiEmbedding
+from pytorch_forecasting.loggers.base_logger import ForecastingLoggerBase
+
+
+class ForecastingTensorBoardLogger(TensorBoardLogger, ForecastingLoggerBase):
+    def __init__(self, *args, **kwargs):
+        super(ForecastingTensorBoardLogger, self).__init__(*args, **kwargs)
+
+    def add_figure(self, caption: str, figure: Figure, step: int) -> None:
+        self.experiment.add_figure(caption, figure, step)
+
+    def add_embeddings(
+        self, input_embeddings: MultiEmbedding, embedding_labels: Dict[str, List[str]], step: int
+    ) -> None:
+        for name, emb in input_embeddings.items():
+            labels = embedding_labels[name]
+            self.experiment.add_embedding(emb.weight.data.detach().cpu(), metadata=labels, tag=name, global_step=step)
+
+    def log_gradient_flow(self, named_parameters: Dict[str, torch.Tensor], step: int) -> None:
+        ave_grads = []
+        layers = []
+        for name, p in named_parameters:
+            if p.grad is not None and p.requires_grad and "bias" not in name:
+                layers.append(name)
+                ave_grads.append(p.grad.abs().mean())
+                self.experiment.add_histogram(tag=name, values=p.grad, global_step=step)
+        fig, ax = plt.subplots()
+        ax.plot(ave_grads)
+        ax.set_xlabel("Layers")
+        ax.set_ylabel("Average gradient")
+        ax.set_yscale("log")
+        ax.set_title("Gradient flow")
+        self.add_figure("Gradient flow", fig, step=step)

--- a/pytorch_forecasting/loggers/wandb_logger/__init__.py
+++ b/pytorch_forecasting/loggers/wandb_logger/__init__.py
@@ -1,0 +1,27 @@
+from typing import List, Dict
+
+import torch
+import wandb
+from matplotlib.figure import Figure
+from pytorch_lightning.loggers import WandbLogger
+
+from pytorch_forecasting import MultiEmbedding
+from pytorch_forecasting.loggers.base_logger import ForecastingLoggerBase
+
+
+class ForecastingWandbLogger(WandbLogger, ForecastingLoggerBase):
+    def __init__(self, *args, **kwargs):
+        super(ForecastingWandbLogger, self).__init__(*args, **kwargs)
+
+    def add_figure(self, caption: str, figure: Figure, step: int) -> None:
+        self.experiment.log({caption: wandb.Image(figure)}, step=step)
+
+    def add_embeddings(
+        self, input_embeddings: MultiEmbedding, embeddings_labels: Dict[str, List[str]], step: int
+    ) -> None:
+        for name, emb in input_embeddings.items():
+            labels = embeddings_labels[name]
+            self.experiment.log({f"embeddings_{name}": wandb.Table(columns=labels, data=emb)}, step=step)
+
+    def log_gradient_flow(self, named_parameters: Dict[str, torch.Tensor], step: int) -> None:
+        pass

--- a/pytorch_forecasting/loggers/wandb_logger/__init__.py
+++ b/pytorch_forecasting/loggers/wandb_logger/__init__.py
@@ -1,9 +1,9 @@
-from typing import List, Dict
+from typing import Dict, List
 
-import torch
-import wandb
 from matplotlib.figure import Figure
 from pytorch_lightning.loggers import WandbLogger
+import torch
+import wandb
 
 from pytorch_forecasting import MultiEmbedding
 from pytorch_forecasting.loggers.base_logger import ForecastingLoggerBase

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -707,16 +707,16 @@ class BaseModel(LightningModule):
                     tag += f" of item {idx} in batch {batch_idx}"
                 if isinstance(fig, (list, tuple)):
                     for idx, f in enumerate(fig):
-                        self.logger.experiment.add_figure(
+                        self.logger.add_figure(
                             f"{self.target_names[idx]} {tag}",
                             f,
-                            global_step=self.global_step,
+                            step=self.global_step,
                         )
                 else:
-                    self.logger.experiment.add_figure(
+                    self.logger.add_figure(
                         tag,
                         fig,
-                        global_step=self.global_step,
+                        step=self.global_step,
                     )
 
     def plot_prediction(
@@ -858,20 +858,7 @@ class BaseModel(LightningModule):
         """
         log distribution of gradients to identify exploding / vanishing gradients
         """
-        ave_grads = []
-        layers = []
-        for name, p in named_parameters:
-            if p.grad is not None and p.requires_grad and "bias" not in name:
-                layers.append(name)
-                ave_grads.append(p.grad.abs().mean())
-                self.logger.experiment.add_histogram(tag=name, values=p.grad, global_step=self.global_step)
-        fig, ax = plt.subplots()
-        ax.plot(ave_grads)
-        ax.set_xlabel("Layers")
-        ax.set_ylabel("Average gradient")
-        ax.set_yscale("log")
-        ax.set_title("Gradient flow")
-        self.logger.experiment.add_figure("Gradient flow", fig, global_step=self.global_step)
+        self.logger.log_gradient_flow(named_parameters, step=self.global_step)
 
     def on_after_backward(self):
         """

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -267,7 +267,7 @@ class NBeats(BaseModel):
                 name += f"step {self.global_step}"
             else:
                 name += f"batch {batch_idx}"
-            self.logger.experiment.add_figure(name, fig, global_step=self.global_step)
+            self.logger.add_figure(name, fig, step=self.global_step)
 
     def plot_interpretation(
         self,

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -772,9 +772,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         label = self.current_stage
         # log to tensorboard
         for name, fig in figs.items():
-            self.logger.experiment.add_figure(
-                f"{label.capitalize()} {name} importance", fig, global_step=self.global_step
-            )
+            self.logger.add_figure(f"{label.capitalize()} {name} importance", fig, step=self.global_step)
 
         # log lengths of encoder/decoder
         for type in ["encoder", "decoder"]:
@@ -794,16 +792,10 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             ax.set_ylabel("Number of samples")
             ax.set_title(f"{type.capitalize()} length distribution in {label} epoch")
 
-            self.logger.experiment.add_figure(
-                f"{label.capitalize()} {type} length distribution", fig, global_step=self.global_step
-            )
+            self.logger.add_figure(f"{label.capitalize()} {type} length distribution", fig, step=self.global_step)
 
     def log_embeddings(self):
         """
         Log embeddings to tensorboard
         """
-        for name, emb in self.input_embeddings.items():
-            labels = self.hparams.embedding_labels[name]
-            self.logger.experiment.add_embedding(
-                emb.weight.data.detach().cpu(), metadata=labels, tag=name, global_step=self.global_step
-            )
+        self.logger.add_embeddings(self.input_embeddings, self.hparams.embeddings_labels, self.global_step)

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -798,4 +798,4 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         """
         Log embeddings to tensorboard
         """
-        self.logger.add_embeddings(self.input_embeddings, self.hparams.embeddings_labels, self.global_step)
+        self.logger.add_embeddings(self.input_embeddings, self.hparams.embedding_labels, self.global_step)

--- a/tests/test_models/test_deepar.py
+++ b/tests/test_models/test_deepar.py
@@ -9,6 +9,7 @@ from test_models.conftest import make_dataloaders
 from torch import nn
 
 from pytorch_forecasting.data.encoders import GroupNormalizer
+from pytorch_forecasting.loggers import ForecastingTensorBoardLogger
 from pytorch_forecasting.metrics import (
     BetaDistributionLoss,
     LogNormalDistributionLoss,
@@ -41,7 +42,7 @@ def _integration(
 
     early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min")
 
-    logger = TensorBoardLogger(tmp_path)
+    logger = ForecastingTensorBoardLogger(tmp_path)
     trainer = pl.Trainer(
         max_epochs=3,
         gpus=gpus,

--- a/tests/test_models/test_deepar.py
+++ b/tests/test_models/test_deepar.py
@@ -4,7 +4,6 @@ import shutil
 import pytest
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
-from pytorch_lightning.loggers import TensorBoardLogger
 from test_models.conftest import make_dataloaders
 from torch import nn
 

--- a/tests/test_models/test_mlp.py
+++ b/tests/test_models/test_mlp.py
@@ -9,6 +9,7 @@ from test_models.conftest import make_dataloaders
 from torch.optim import SGD
 from torchmetrics import MeanSquaredError
 
+from pytorch_forecasting.loggers import ForecastingTensorBoardLogger
 from pytorch_forecasting.metrics import MAE, CrossEntropy, MultiLoss, QuantileLoss
 from pytorch_forecasting.models import DecoderMLP
 
@@ -30,7 +31,7 @@ def _integration(data_with_covariates, tmp_path, gpus, data_loader_kwargs={}, tr
         monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min", strict=False
     )
 
-    logger = TensorBoardLogger(tmp_path)
+    logger = ForecastingTensorBoardLogger(tmp_path)
     trainer = pl.Trainer(
         max_epochs=3,
         gpus=gpus,

--- a/tests/test_models/test_mlp.py
+++ b/tests/test_models/test_mlp.py
@@ -4,7 +4,6 @@ import shutil
 import pytest
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import EarlyStopping
-from pytorch_lightning.loggers import TensorBoardLogger
 from test_models.conftest import make_dataloaders
 from torch.optim import SGD
 from torchmetrics import MeanSquaredError

--- a/tests/test_models/test_nbeats.py
+++ b/tests/test_models/test_nbeats.py
@@ -6,6 +6,7 @@ import pytorch_lightning as pl
 from pytorch_lightning.callbacks import EarlyStopping
 from pytorch_lightning.loggers import TensorBoardLogger
 
+from pytorch_forecasting.loggers import ForecastingTensorBoardLogger
 from pytorch_forecasting.models import NBeats
 
 
@@ -16,7 +17,7 @@ def test_integration(dataloaders_fixed_window_without_covariates, tmp_path, gpus
 
     early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min")
 
-    logger = TensorBoardLogger(tmp_path)
+    logger = ForecastingTensorBoardLogger(tmp_path)
     trainer = pl.Trainer(
         max_epochs=2,
         gpus=gpus,

--- a/tests/test_models/test_nbeats.py
+++ b/tests/test_models/test_nbeats.py
@@ -4,7 +4,6 @@ import shutil
 import pytest
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import EarlyStopping
-from pytorch_lightning.loggers import TensorBoardLogger
 
 from pytorch_forecasting.loggers import ForecastingTensorBoardLogger
 from pytorch_forecasting.models import NBeats

--- a/tests/test_models/test_rnn_model.py
+++ b/tests/test_models/test_rnn_model.py
@@ -9,6 +9,7 @@ from test_models.conftest import make_dataloaders
 from torch import nn
 
 from pytorch_forecasting.data.encoders import GroupNormalizer
+from pytorch_forecasting.loggers import ForecastingTensorBoardLogger
 from pytorch_forecasting.metrics import MAE, CrossEntropy, QuantileLoss
 from pytorch_forecasting.models import RecurrentNetwork
 
@@ -36,7 +37,7 @@ def _integration(
 
     early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min")
 
-    logger = TensorBoardLogger(tmp_path)
+    logger = ForecastingTensorBoardLogger(tmp_path)
     trainer = pl.Trainer(
         max_epochs=3,
         gpus=gpus,

--- a/tests/test_models/test_rnn_model.py
+++ b/tests/test_models/test_rnn_model.py
@@ -4,7 +4,6 @@ import shutil
 import pytest
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import EarlyStopping
-from pytorch_lightning.loggers import TensorBoardLogger
 from test_models.conftest import make_dataloaders
 from torch import nn
 

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -11,6 +11,7 @@ import torch
 from pytorch_forecasting import TimeSeriesDataSet
 from pytorch_forecasting.data import NaNLabelEncoder
 from pytorch_forecasting.data.encoders import GroupNormalizer, MultiNormalizer
+from pytorch_forecasting.loggers import ForecastingTensorBoardLogger
 from pytorch_forecasting.metrics import (
     CrossEntropy,
     MultiLoss,
@@ -60,7 +61,7 @@ def _integration(dataloader, tmp_path, gpus, loss=None):
     early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min")
 
     # check training
-    logger = TensorBoardLogger(tmp_path)
+    logger = ForecastingTensorBoardLogger(tmp_path)
     trainer = pl.Trainer(
         max_epochs=2,
         gpus=gpus,

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -5,7 +5,6 @@ import sys
 import pytest
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
-from pytorch_lightning.loggers import TensorBoardLogger
 import torch
 
 from pytorch_forecasting import TimeSeriesDataSet
@@ -180,7 +179,7 @@ def model(dataloaders_with_covariates, gpus):
 
 def test_tensorboard_graph_log(dataloaders_with_covariates, model, tmp_path):
     d = next(iter(dataloaders_with_covariates["train"]))
-    logger = TensorBoardLogger("test", str(tmp_path), log_graph=True)
+    logger = ForecastingTensorBoardLogger("test", str(tmp_path), log_graph=True)
     logger.log_graph(model, d[0])
 
 
@@ -199,7 +198,7 @@ def test_distribution(dataloaders_with_covariates, tmp_path, accelerator, gpus):
     net = TemporalFusionTransformer.from_dataset(
         train_dataloader.dataset,
     )
-    logger = TensorBoardLogger(tmp_path)
+    logger = ForecastingTensorBoardLogger(tmp_path)
     trainer = pl.Trainer(
         max_epochs=3,
         gpus=list(range(torch.cuda.device_count())),


### PR DESCRIPTION
### Description

This PR resolves #89.
* I created a base logger class (`loggers.ForecastingLoggerBase`) to handle different loggers (e.g., TensorBoard, Wandb) using the same syntax. This inherits from the PyTorch Lightning logger base class, and implements three new methods used across the PyTorch Forecasting project: `add_figure`, `add_embeddings`, and `log_gradient_flow`.
* I implemented two new logger classes for TensorBoard and Wandb based on `loggers.ForecastingLoggerBase`, and inheriting from their PyTorch Lightning counterparts (respectively `pytorch_lightning.loggers.TensorBoardLogger` and `pytorch_lightning.loggers.WandbLogger`).
* I modified the tests, replacing all the `pytorch_lightning.loggers.TensorBoardLogger` instances with the newly created `loggers.ForecastingTensorBoardLogger`.

As for the Wandb logger, `loggers.ForecastingWandbLogger`, I was wondering if someone could guide me on how to structure its tests.

### Checklist

- [x] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`
