### PR TITLE
Fix warning in timeseries collate function

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1651,8 +1651,8 @@ class TimeSeriesDataSet(Dataset):
                 if isinstance(batches[0][0]["target_scale"][idx], torch.Tensor):  # stack tensor
                     scale = torch.stack([batch[0]["target_scale"][idx] for batch in batches])
                 else:
-                    scale = torch.tensor(
-                        np.array([batch[0]["target_scale"][idx] for batch in batches]), dtype=torch.float
+                    scale = torch.from_numpy(
+                        np.array([batch[0]["target_scale"][idx] for batch in batches], dtype=np.float32),
                     )
                 target_scale.append(scale)
         else:  # convert to tensor

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1651,7 +1651,9 @@ class TimeSeriesDataSet(Dataset):
                 if isinstance(batches[0][0]["target_scale"][idx], torch.Tensor):  # stack tensor
                     scale = torch.stack([batch[0]["target_scale"][idx] for batch in batches])
                 else:
-                    scale = torch.tensor([batch[0]["target_scale"][idx] for batch in batches], dtype=torch.float)
+                    scale = torch.tensor(
+                        np.array([batch[0]["target_scale"][idx] for batch in batches]), dtype=torch.float
+                    )
                 target_scale.append(scale)
         else:  # convert to tensor
             target_scale = torch.tensor([batch[0]["target_scale"] for batch in batches], dtype=torch.float)


### PR DESCRIPTION
### Description

This PR fixes this warning given by PyTorch in the collate function of the timeseries data script:

```
../anaconda3/envs/env/lib/python3.8/site-packages/pytorch_forecasting/data/timeseries.py:1654:
UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow.
Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor.
(Triggered internally at  ../torch/csrc/utils/tensor_new.cpp:201.)
--> scale = torch.tensor([batch[0]["target_scale"][idx] for batch in batches], dtype=torch.float)
```

The list of numpy arrays is casted into a single numpy array before being casted to a torch tensor.

Notice that there is probably a small bug in the `log_gradient_flow` method of the `BaseModel`, for which some tests don't pass. More details on that can be found in the last note of PR #816. Replacing `p.grad` with `p.grad.cpu()` solves the issue and makes all tests pass, but a better solution is proposed in #816. 

### Checklist

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified test
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`