### PR TITLE
Fix another numpy to torch conversion warning

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1656,7 +1656,9 @@ class TimeSeriesDataSet(Dataset):
                     )
                 target_scale.append(scale)
         else:  # convert to tensor
-            target_scale = torch.tensor([batch[0]["target_scale"] for batch in batches], dtype=torch.float)
+            target_scale = torch.from_numpy(
+                np.array([batch[0]["target_scale"] for batch in batches], dtype=np.float32),
+            )
 
         # target and weight
         if isinstance(batches[0][1][0], (tuple, list)):


### PR DESCRIPTION
### Description

Fixes another warning when converting from numpy to torch in collate function.


### Checklist

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
