### PR TITLE
More flexible multiembedding

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,8 @@
 name: Dependabot auto-merge
-on: pull_request
+on:
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
 
 permissions:
   pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Allow using [torchmetrics](https://torchmetrics.readthedocs.io/) as loss metrics (#776)
 - Enable fitting `EncoderNormalizer()` with limited data history using `max_length` argument (#782)
+- More flexible `MultiEmbedding()` with convenience `output_size` and `input_size` properties (#829)
 
 ### Fixed
 

--- a/pytorch_forecasting/models/basic_rnn/__init__.py
+++ b/pytorch_forecasting/models/basic_rnn/__init__.py
@@ -100,7 +100,7 @@ class LSTMModel(AutoRegressiveBaseModelWithCovariates):
 
         time_series_rnn = get_rnn(cell_type)
         cont_size = len(self.reals)
-        cat_size = sum([size[1] for size in self.hparams.embedding_sizes.values()])
+        cat_size = sum(self.embeddings.output_size.values())
         input_size = cont_size + cat_size
         self.rnn = time_series_rnn(
             input_size=input_size,

--- a/pytorch_forecasting/models/deepar/__init__.py
+++ b/pytorch_forecasting/models/deepar/__init__.py
@@ -140,7 +140,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
 
         rnn_class = get_rnn(cell_type)
         cont_size = len(self.reals)
-        cat_size = sum([size[1] for size in self.hparams.embedding_sizes.values()])
+        cat_size = sum(self.embeddings.output_size.values())
         input_size = cont_size + cat_size
         self.rnn = rnn_class(
             input_size=input_size,

--- a/pytorch_forecasting/models/mlp/__init__.py
+++ b/pytorch_forecasting/models/mlp/__init__.py
@@ -104,7 +104,7 @@ class DecoderMLP(BaseModelWithCovariates):
             mlp_output_size = sum(self.hparams.output_size)
 
         cont_size = len(self.decoder_reals_positions)
-        cat_size = sum([emb.embedding_dim for emb in self.input_embeddings.values()])
+        cat_size = sum(self.input_embeddings.output_size.values())
         input_size = cont_size + cat_size
 
         self.mlp = FullyConnectedModule(

--- a/pytorch_forecasting/models/nn/embeddings.py
+++ b/pytorch_forecasting/models/nn/embeddings.py
@@ -48,16 +48,18 @@ class MultiEmbedding(nn.Module):
         Args:
             embedding_sizes (Union[Dict[str, Tuple[int, int]], Dict[str, int], List[int], List[Tuple[int, int]]]):
                 either
+
                 * dictionary of embedding sizes, e.g. ``{'cat1': (10, 3)}``
-                 indicates that the first categorical variable has 10 unique values which are mapped to 3 embedding
-                 dimensions. Use :py:func:`~pytorch_forecasting.utils.get_embedding_size` to automatically obtain
-                 reasonable embedding sizes depending on the number of categories.
+                  indicates that the first categorical variable has 10 unique values which are mapped to 3 embedding
+                  dimensions. Use :py:func:`~pytorch_forecasting.utils.get_embedding_size` to automatically obtain
+                  reasonable embedding sizes depending on the number of categories.
                 * dictionary of categorical sizes, e.g. ``{'cat1': 10}`` where embedding sizes are inferred by
                   :py:func:`~pytorch_forecasting.utils.get_embedding_size`.
                 * list of embedding and categorical sizes, e.g. ``[(10, 3), (20, 2)]`` (requires ``x_categoricals`` to
                   be empty)
                 * list of categorical sizes where embedding sizes are inferred by
                   :py:func:`~pytorch_forecasting.utils.get_embedding_size` (requires ``x_categoricals`` to be empty).
+
                 If input is provided as list, output will be a single tensor of shape batch x (optional) time x
                 sum(embedding_sizes). Otherwise, output is a dictionary of embedding tensors.
             x_categoricals (List[str]): list of categorical variables that are used as input.

--- a/pytorch_forecasting/models/nn/embeddings.py
+++ b/pytorch_forecasting/models/nn/embeddings.py
@@ -1,6 +1,9 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
+import torch
 import torch.nn as nn
+
+from pytorch_forecasting.utils import get_embedding_size
 
 
 class TimeDistributedEmbeddingBag(nn.EmbeddingBag):
@@ -27,16 +30,64 @@ class TimeDistributedEmbeddingBag(nn.EmbeddingBag):
 
 
 class MultiEmbedding(nn.Module):
+
+    concat_output: bool
+
     def __init__(
         self,
-        embedding_sizes: Dict[str, Tuple[int, int]],
-        categorical_groups: Dict[str, List[str]],
-        embedding_paddings: List[str],
-        x_categoricals: List[str],
+        embedding_sizes: Union[Dict[str, Tuple[int, int]], Dict[str, int], List[int], List[Tuple[int, int]]],
+        x_categoricals: List[str] = None,
+        categorical_groups: Dict[str, List[str]] = {},
+        embedding_paddings: List[str] = [],
         max_embedding_size: int = None,
     ):
+        """Embedding layer for categorical variables including groups of categorical variables.
+
+        Enabled for static and dynamic categories (i.e. 3 dimensions for batch x time x categories).
+
+        Args:
+            embedding_sizes (Union[Dict[str, Tuple[int, int]], Dict[str, int], List[int], List[Tuple[int, int]]]):
+                either
+                * dictionary of embedding sizes, e.g. ``{'cat1': (10, 3)}``
+                 indicates that the first categorical variable has 10 unique values which are mapped to 3 embedding
+                 dimensions. Use :py:func:`~pytorch_forecasting.utils.get_embedding_size` to automatically obtain
+                 reasonable embedding sizes depending on the number of categories.
+                * dictionary of categorical sizes, e.g. ``{'cat1': 10}`` where embedding sizes are inferred by
+                  :py:func:`~pytorch_forecasting.utils.get_embedding_size`.
+                * list of embedding and categorical sizes, e.g. ``[(10, 3), (20, 2)]`` (requires ``x_categoricals`` to
+                  be empty)
+                * list of categorical sizes where embedding sizes are inferred by
+                  :py:func:`~pytorch_forecasting.utils.get_embedding_size` (requires ``x_categoricals`` to be empty).
+                If input is provided as list, output will be a single tensor of shape batch x (optional) time x
+                sum(embedding_sizes). Otherwise, output is a dictionary of embedding tensors.
+            x_categoricals (List[str]): list of categorical variables that are used as input.
+            categorical_groups (Dict[str, List[str]]): dictionary of categories that should be summed up in an
+                embedding bag, e.g. ``{'cat1': ['cat2', 'cat3']}`` indicates that a new categorical variable ``'cat1'``
+                is mapped to an embedding bag containing the second and third categorical variables.
+                Defaults to empty dictionary.
+            embedding_paddings (List[str]): list of categorical variables for which the value 0 is mapped to a zero
+                embedding vector. Defaults to empty list.
+            max_embedding_size (int, optional): if embedding size defined by ``embedding_sizes`` is larger than
+                ``max_embedding_size``, it will be constrained. Defaults to None.
+        """
         super().__init__()
-        self.embedding_sizes = embedding_sizes
+        if not isinstance(embedding_sizes, dict):
+            assert (
+                x_categoricals is None and len(categorical_groups) == 0
+            ), "If embedding_sizes is not a dictionary, categorical_groups and x_categoricals must be empty."
+            # number embeddings based on order
+            embedding_sizes = {str(name): size for name, size in enumerate(embedding_sizes)}
+            x_categoricals = list(embedding_sizes.keys())
+            self.concat_output = True
+        else:
+            self.concat_output = False
+        assert x_categoricals is not None, "x_categoricals must be provided."
+
+        # infer embedding sizes if not determined
+        self.embedding_sizes = {
+            name: (size, get_embedding_size(size)) if isinstance(size, int) else size
+            for name, size in embedding_sizes.items()
+        }
         self.categorical_groups = categorical_groups
         self.embedding_paddings = embedding_paddings
         self.max_embedding_size = max_embedding_size
@@ -83,7 +134,29 @@ class MultiEmbedding(nn.Module):
     def __getitem__(self, name: str):
         return self.embeddings[name]
 
-    def forward(self, x):
+    @property
+    def input_size(self) -> int:
+        return len(self.x_categoricals)
+
+    @property
+    def output_size(self) -> Union[Dict[str, int], int]:
+        if self.concat_output:
+            return sum([s[1] for s in self.embedding_sizes.values()])
+        else:
+            return {name: s[1] for name, s in self.embedding_sizes.items()}
+
+    def forward(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """
+        Args:
+            x (torch.Tensor): input tensor of shape batch x (optional) time x categoricals in the order of
+                ``x_categoricals``.
+
+        Returns:
+            Union[Dict[str, torch.Tensor], torch.Tensor]: dictionary of category names to embeddings
+                of shape batch x (optional) time x embedding_size if ``embedding_size`` is given as dictionary.
+                Otherwise, returns the embedding of shape batch x (optional) time x sum(embedding_sizes).
+                Query attribute ``output_size`` to get the size of the output(s).
+        """
         input_vectors = {}
         for name, emb in self.embeddings.items():
             if name in self.categorical_groups:
@@ -95,4 +168,7 @@ class MultiEmbedding(nn.Module):
                 )
             else:
                 input_vectors[name] = emb(x[..., self.x_categoricals.index(name)])
+
+        if self.concat_output:  # concatenate output
+            return torch.cat(list(input_vectors.values()), dim=-1)
         return input_vectors

--- a/pytorch_forecasting/models/rnn/__init__.py
+++ b/pytorch_forecasting/models/rnn/__init__.py
@@ -109,7 +109,7 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
 
         rnn_class = get_rnn(cell_type)
         cont_size = len(self.reals)
-        cat_size = sum([size[1] for size in self.hparams.embedding_sizes.values()])
+        cat_size = sum(self.embeddings.output_size.values())
         input_size = cont_size + cat_size
         self.rnn = rnn_class(
             input_size=input_size,

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -159,7 +159,9 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
 
         # variable selection
         # variable selection for static variables
-        static_input_sizes = {name: self.hparams.embedding_sizes[name][1] for name in self.hparams.static_categoricals}
+        static_input_sizes = {
+            name: self.input_embeddings.output_size[name] for name in self.hparams.static_categoricals
+        }
         static_input_sizes.update(
             {
                 name: self.hparams.hidden_continuous_sizes.get(name, self.hparams.hidden_continuous_size)
@@ -176,7 +178,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
 
         # variable selection for encoder and decoder
         encoder_input_sizes = {
-            name: self.hparams.embedding_sizes[name][1] for name in self.hparams.time_varying_categoricals_encoder
+            name: self.input_embeddings.output_size[name] for name in self.hparams.time_varying_categoricals_encoder
         }
         encoder_input_sizes.update(
             {
@@ -186,7 +188,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         )
 
         decoder_input_sizes = {
-            name: self.hparams.embedding_sizes[name][1] for name in self.hparams.time_varying_categoricals_decoder
+            name: self.input_embeddings.output_size[name] for name in self.hparams.time_varying_categoricals_decoder
         }
         decoder_input_sizes.update(
             {

--- a/tests/test_models/test_nn/test_embeddings.py
+++ b/tests/test_models/test_nn/test_embeddings.py
@@ -1,0 +1,39 @@
+import itertools
+
+import pytest
+import torch
+
+from pytorch_forecasting import MultiEmbedding
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(embedding_sizes=(10, 10, 10)),
+        dict(embedding_sizes=((10, 3), (10, 2), (10, 1))),
+        dict(x_categoricals=["x1", "x2", "x3"], embedding_sizes=dict(x1=(10, 10))),
+        dict(
+            x_categoricals=["x1", "x2", "x3"],
+            embedding_sizes=dict(x1=(10, 2), xg1=(10, 3)),
+            categorical_groups=dict(xg1=["x2", "x3"]),
+        ),
+    ],
+)
+def test_MultiEmbedding(kwargs):
+    x = torch.randint(0, 10, size=(4, 3))
+    embedding = MultiEmbedding(**kwargs)
+    assert embedding.input_size == x.size(1), "Input size should be equal to number of features"
+    out = embedding(x)
+    if isinstance(out, dict):
+        assert isinstance(kwargs["embedding_sizes"], dict)
+        for name, o in out.items():
+            assert (
+                o.size(1) == embedding.output_size[name]
+            ), "Output size should be equal to number of embedding dimensions"
+    elif isinstance(out, torch.Tensor):
+        assert isinstance(kwargs["embedding_sizes"], (tuple, list))
+        assert (
+            out.size(1) == embedding.output_size
+        ), "Output size should be equal to number of summed embedding dimensions"
+    else:
+        raise ValueError(f"Unknown output type {type(out)}")


### PR DESCRIPTION
### Description

This PR makes the MultiEmbedding a bit more flexible and adds additional properties for convenience to deduce output and input sizes.

### Checklist

- [x] Amended changelog for large changes (and added myself there as contributor)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
