### PR TITLE
fixed issue with calculate_prediction_actual_by_variable not working with int decoder_targets

### DIFF
--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -1484,7 +1484,7 @@ class BaseModelWithCovariates(BaseModel):
         max_encoder_length = x["decoder_lengths"].max()
         mask = create_mask(max_encoder_length, x["decoder_lengths"], inverse=True)
         # select valid y values
-        y_flat = x["decoder_target"][mask]
+        y_flat = x["decoder_target"][mask].double()
         y_pred_flat = y_pred[mask]
 
         # determine in which average in log-space to transform data


### PR DESCRIPTION
### Description

This PR converts x["decoder_target"] to double to ensure torch.mean() works.