### PR TITLE
Possible fix for adding new group ids when using from_dataset

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -660,7 +660,7 @@ class TimeSeriesDataSet(Dataset):
             group_ids_to_encode = self.group_ids
         else:
             group_ids_to_encode = []
-        for name in dict.fromkeys(group_ids_to_encode + self.categoricals):
+        for name in dict.fromkeys(self.categoricals):
             if name in self.lagged_variables:
                 continue  # do not encode here but only in transform
             if name in self.variable_groups:  # fit groups
@@ -688,7 +688,11 @@ class TimeSeriesDataSet(Dataset):
             # targets and its lagged versions are handled separetely
             if name not in self.target_names and name not in self.lagged_targets:
                 data[name] = self.transform_values(
-                    name, data[name], inverse=False, ignore_na=name in self.lagged_variables
+                    name=name,
+                    values=data[name],
+                    inverse=False,
+                    group_id=name in self._group_ids_mapping,
+                    ignore_na=name in self.lagged_variables,
                 )
 
         # save special variables


### PR DESCRIPTION
I am trying to use the TFT forecasting algorithm for the first time. I may have misunderstood the intended use of this library, but my idea is as follows: first make a training TimeSeriesDataSet using the class constructor, train the TFT on that, and then create a test dataset with the same transformations as the training set using 'from_dataset'. Since the test set contains independent data from the training set, most of the group ids in the test set are not present in the training set. 

When I try to run 'from_dataset', I get an error saying "Unknown category '----' encountered. Set `add_nan=True` to allow unknown categories" with one of my group ids where the bars go. When I looked at the code, it seemed like this was supposed to work, and I was able to run my code after doing a minor modification.