### PR TITLE
Bug fix for warning: The metric 'val_loss' is not in the evaluation logs for pruning.

### DIFF
--- a/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
@@ -209,7 +209,10 @@ def optimize_hyperparameters(
         trainer.fit(model, train_dataloaders=train_dataloader, val_dataloaders=val_dataloader)
 
         # report result
-        return metrics_callback.metrics[-1]["val_loss"].item()
+        if "val_loss" in metrics_callback.metrics[-1].keys():
+            return metrics_callback.metrics[-1]["val_loss"].item()
+        else:
+            return metrics_callback.metrics[-1]["sanity_check_loss"].item()
 
     # setup optuna and run
     if study is None:


### PR DESCRIPTION
With this change the following warning does not occur anymore:
```
/usr/local/lib/python3.7/dist-packages/optuna/integration/pytorch_lightning.py:52: UserWarning:
The metric 'val_loss' is not in the evaluation logs for pruning. Please make sure you set the correct metric name.
```