### PR TITLE
Fix attention concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v0.10.0 Adding N-HiTS network (N-BEATS successor) (UNRELEASED)
+## v0.10.0 Adding N-HiTS network (N-BEATS successor) (23/03/2022)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v0.10.0 UNRELEASED
+## v0.10.0 Adding N-HiTS network (N-BEATS successor) (UNRELEASED)
 
 ### Added
 
@@ -8,6 +8,7 @@
 - Allow using [torchmetrics](https://torchmetrics.readthedocs.io/) as loss metrics (#776)
 - Enable fitting `EncoderNormalizer()` with limited data history using `max_length` argument (#782)
 - More flexible `MultiEmbedding()` with convenience `output_size` and `input_size` properties (#829)
+- Fix concatentation of attention (#902)
 
 ### Fixed
 

--- a/pytorch_forecasting/metrics.py
+++ b/pytorch_forecasting/metrics.py
@@ -745,9 +745,9 @@ class PoissonLoss(MultiHorizonMetric):
             else:
                 quantiles = self.quantiles
         predictions = super().to_prediction(out)
-        return torch.stack([torch.tensor(scipy.stats.poisson(predictions.cpu()).ppf(q)) for q in quantiles], dim=-1).to(
-            predictions.device
-        )
+        return torch.stack(
+            [torch.tensor(scipy.stats.poisson(predictions.detach().numpy()).ppf(q)) for q in quantiles], dim=-1
+        ).to(predictions.device)
 
 
 class QuantileLoss(MultiHorizonMetric):

--- a/pytorch_forecasting/utils.py
+++ b/pytorch_forecasting/utils.py
@@ -447,3 +447,28 @@ def detach(
         return [detach(xi) for xi in x]
     else:
         return x
+
+
+def masked_op(tensor: torch.Tensor, op: str = "mean", dim: int = 0, mask: torch.Tensor = None) -> torch.Tensor:
+    """Calculate operation on masked tensor.
+
+    Args:
+        tensor (torch.Tensor): tensor to conduct operation over
+        op (str): operation to apply. One of ["mean", "sum"]. Defaults to "mean".
+        dim (int, optional): dimension to average over. Defaults to 0.
+        mask (torch.Tensor, optional): boolean mask to apply (True=will take mean, False=ignore).
+            Masks nan values by default.
+
+    Returns:
+        torch.Tensor: tensor with averaged out dimension
+    """
+    if mask is None:
+        mask = ~torch.isnan(tensor)
+    masked = tensor.masked_fill(~mask, 0.0)
+    summed = masked.sum(dim=dim)
+    if op == "mean":
+        return summed / mask.sum(dim=dim)  # Find the average
+    elif op == "sum":
+        return summed
+    else:
+        raise ValueError(f"unkown operation {op}")

--- a/pytorch_forecasting/utils.py
+++ b/pytorch_forecasting/utils.py
@@ -338,6 +338,17 @@ class OutputMixIn:
     def keys(self):
         return self._fields
 
+    def iget(self, idx: Union[int, slice]):
+        """Select item(s) row-wise.
+
+        Args:
+            idx ([int, slice]): item to select
+
+        Returns:
+            Output of single item.
+        """
+        return self.__class__(*(x[idx] for x in self))
+
 
 class TupleOutputMixIn:
     """MixIn to give output a namedtuple-like access capabilities with ``to_network_output() function``."""

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -285,7 +285,7 @@ def test_prediction_with_dataloder_raw(data_with_covariates, tmp_path):
         attention_head_size=1,
         dropout=0.2,
         hidden_continuous_size=2,
-        # loss=PoissonLoss(),
+        loss=PoissonLoss(),
         log_interval=1,
         log_val_interval=1,
         log_gradient_flow=True,


### PR DESCRIPTION
### Description

This PR fixes an issue with attention calculation accross many samples and predict(mode="raw") failing.

### Checklist

- [x] Linked issues (if existing)
- [x] Amended changelog for large changes (and added myself there as contributor)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
