### PR TITLE
Fix typing management in _data_to_tensors

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -964,24 +964,21 @@ class TimeSeriesDataSet(Dataset):
         """
 
         index = check_for_nonfinite(
-            torch.tensor(data[self._group_ids].to_numpy(np.int64), dtype=torch.int64), self.group_ids
+            torch.from_numpy(data[self._group_ids].to_numpy(np.int64).copy()), self.group_ids
         )
         time = check_for_nonfinite(
-            torch.tensor(data["__time_idx__"].to_numpy(np.int64), dtype=torch.int64), self.time_idx
+            torch.from_numpy(data["__time_idx__"].to_numpy(np.int64).copy()), self.time_idx
         )
 
         # categorical covariates
         categorical = check_for_nonfinite(
-            torch.tensor(data[self.flat_categoricals].to_numpy(np.int64), dtype=torch.int64), self.flat_categoricals
+            torch.from_numpy(data[self.flat_categoricals].to_numpy(np.int64).copy()), self.flat_categoricals
         )
 
         # get weight
         if self.weight is not None:
             weight = check_for_nonfinite(
-                torch.tensor(
-                    data["__weight__"].to_numpy(dtype=np.float64),
-                    dtype=torch.float,
-                ),
+                torch.from_numpy(data["__weight__"].to_numpy(dtype=np.float64).copy()),
                 self.weight,
             )
         else:
@@ -991,7 +988,7 @@ class TimeSeriesDataSet(Dataset):
         if isinstance(self.target_normalizer, NaNLabelEncoder):
             target = [
                 check_for_nonfinite(
-                    torch.tensor(data[f"__target__{self.target}"].to_numpy(dtype=np.int64), dtype=torch.long),
+                    torch.from_numpy(data[f"__target__{self.target}"].to_numpy(dtype=np.int64).copy()),
                     self.target,
                 )
             ]
@@ -999,11 +996,10 @@ class TimeSeriesDataSet(Dataset):
             if not isinstance(self.target, str):  # multi-target
                 target = [
                     check_for_nonfinite(
-                        torch.tensor(
+                        torch.from_numpy(
                             data[f"__target__{name}"].to_numpy(
                                 dtype=[np.float64, np.int64][data[name].dtype.kind in "bi"]
-                            ),
-                            dtype=[torch.float, torch.long][data[name].dtype.kind in "bi"],
+                            ).copy(),
                         ),
                         name,
                     )
@@ -1012,7 +1008,7 @@ class TimeSeriesDataSet(Dataset):
             else:
                 target = [
                     check_for_nonfinite(
-                        torch.tensor(data[f"__target__{self.target}"].to_numpy(dtype=np.float64), dtype=torch.float),
+                        torch.from_numpy(data[f"__target__{self.target}"].to_numpy(dtype=np.float64).copy()),
                         self.target,
                     )
                 ]


### PR DESCRIPTION
### Description

The starting point is:
The target value is changed to np.float64 and then to torch.float (float32 by default) with this code:
```python
target = [
                    check_for_nonfinite(
                        torch.tensor(data[f"__target__{self.target}"].to_numpy(dtype=np.float64), dtype=torch.float),
                        self.target,
                    )
]
```
This caused this code to output `false`:
```python
r = pd.DataFrame({'timestamp': np.arange(0, 10), 'target': np.random.rand(10), 'grp': np.ones(10)})
rts = TimeSeriesDataSet(r, time_idx='timestamp', target='target', group_ids=['grp'],
                        time_varying_unknown_reals=['target'],
                        time_varying_known_reals=['timestamp'],
                        max_encoder_length=2,
                        max_prediction_length=2,
                        )

X, (y, _) = next(iter(rts))

a = X['encoder_target'][0].item()
print(a == r.target[0])
```

I first fixed it by doing torch.float64 instead of torch.float, but then changed it to `torch.from_numpy(data[f"__target__{self.target}"].to_numpy(dtype=np.float64).copy()` which is faster according to my benchmark. I do copy() to keep the same hebavior as `torch.tensor()` previously used.

```python
r = np.random.randint(0, 10, (10000))
%timeit torch.tensor(pd.Series(r).to_numpy(dtype=np.int64), dtype=torch.long)
%timeit torch.from_numpy(pd.Series(r).to_numpy(dtype=np.int64).copy())
%timeit torch.from_numpy(pd.Series(r).to_numpy(dtype=np.int64)).clone()
%timeit torch.tensor(pd.Series(r).to_numpy(), dtype=torch.long)
# Note: Similar results for float64 values
->
106 µs ± 3.91 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
83.8 µs ± 9.3 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
101 µs ± 6.35 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
96.2 µs ± 1.63 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

I then applied the same modification wherever I found it relevant.

Going from numpy to torch.tensor using `from_numpy` always output the excepted type for torch.tensor i.e.
````python
torch.from_numpy(a.astype(np.float64)).dtype  # torch.float64 
torch.from_numpy(a.astype(np.int64)).dtype  # torch.int64   (Please note this is the same as torch.long. It was mixed up in the code)
````



### Checklist

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
