### PR TITLE
bugfix: dtype inconsistency in TorchNormalizer with method='identity'

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -464,8 +464,11 @@ class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, Transform
                 self.center_ = torch.zeros(y_center.size()[:-1])
                 self.scale_ = torch.ones(y_scale.size()[:-1])
             elif isinstance(y_center, (np.ndarray, pd.Series, pd.DataFrame)):
-                self.center_ = np.zeros(y_center.shape[:-1])
-                self.scale_ = np.ones(y_scale.shape[:-1])
+                # numpy default type is numpy.float64 while torch default type is torch.float32 (if not changed)
+                # therefore, we first generate torch tensors (with torch default type) and then
+                # convert them to numpy arrays
+                self.center_ = torch.zeros(y_center.shape[:-1]).numpy()
+                self.scale_ = torch.ones(y_scale.shape[:-1]).numpy()
             else:
                 self.center_ = 0.0
                 self.scale_ = 1.0
@@ -481,7 +484,7 @@ class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, Transform
                 self.center_ = np.mean(y_center)
                 self.scale_ = np.std(y_scale) + eps
             # correct numpy scalar dtype promotion, e.g. fix type from `np.float32(0.0) + 1e-8` gives `np.float64(1e-8)`
-            if isinstance(self.scale_, np.ndarray) and np.isscalar(self.scale_):
+            if isinstance(self.scale_, np.ndarray):
                 self.scale_ = self.scale_.astype(y_scale.dtype)
 
         elif self.method == "robust":

--- a/tests/test_data/test_encoders.py
+++ b/tests/test_data/test_encoders.py
@@ -153,8 +153,14 @@ def test_MultiNormalizer_fitted():
 
 
 def test_TorchNormalizer_dtype_consistency():
-    """Ensures that even for float64 `target_scale`, the transformation will not change the prediction dtype."""
+    """
+    - Ensures that even for float64 `target_scale`, the transformation will not change the prediction dtype.
+    - Ensure that target_scale will be of type float32 if method is 'identity'
+    """
     parameters = torch.tensor([[[366.4587]]])
     target_scale = torch.tensor([[427875.7500, 80367.4766]], dtype=torch.float64)
     assert TorchNormalizer()(dict(prediction=parameters, target_scale=target_scale)).dtype == torch.float32
     assert TorchNormalizer().transform(parameters, target_scale=target_scale).dtype == torch.float32
+
+    y = np.array([1, 2, 3], dtype=np.float32)
+    assert TorchNormalizer(method="identity").fit(y).get_parameters().dtype == torch.float32


### PR DESCRIPTION
### Description

This PR aims at fixing issue #998 by making changes in method `_set_parameters` of `TorchNormalizer`.
The following assertion was added in `tests/test_data/test_encoders.py`:
```
y = np.array([1, 2, 3], dtype=np.float32)
assert TorchNormalizer(method="identity").fit(y).get_parameters().dtype == torch.float32
```
Before the changes made, this assertion would fail (the dtype would be `torch.float64` due to numpy default dtype `numpy.float64`) which then would potentially cause dtype issues (e.g., in method `decode` of DeepAR and more specifically `decode_autoregressive`: the first lagged value was of dtype torch.float32 -true observed value- while the subsequent values -predictions- were of dtype torch.float64).

Not 100% sure the problem should not have been fixed on DeepAR side but note that a similar fix of dtype was already implemented in `TorchNormalizer`: 
```
# correct numpy scalar dtype promotion, e.g. fix type from `np.float32(0.0) + 1e-8` gives `np.float64(1e-8)`
if isinstance(self.scale_, np.ndarray):
    self.scale_ = self.scale_.astype(y_scale.dtype)
```

### Checklist

- [x] Related Github issues: #998
- [x] Added/modified tests: `tests/test_data/test_encoders.py`
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.
