### PR TITLE
Fix the slice for plotting attention

### DIFF
--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -728,7 +728,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
                 encoder_length = x["encoder_lengths"][0]
                 ax2.plot(
                     torch.arange(-encoder_length, 0),
-                    interpretation["attention"][0, -encoder_length:].detach().cpu(),
+                    interpretation["attention"][0, :-encoder_length].detach().cpu(),
                     alpha=0.2,
                     color="k",
                 )


### PR DESCRIPTION
### Description

Before the fix, works only when `interpretation["attention"]` matches `encoder_length` (in which case the slice is not needed anyway). After, length matches always. 

I'm running into this with encoder_length=0, which is probably a bug elsewhere, possibly in my code, but this is probably worth fixing anyway.

### Checklist

NOT YET, will do if PR is desired

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
