### PR TITLE
Feature/bidirectional lstm decoder

### DIFF
--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -490,8 +490,10 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             #       documentation that specifies how the input of the `forward`
             #       of a bidirectional LSTM layer is processed. The call gets
             #       passed to `torch.onnx.symbolic_opset9.py` but gets
-            #       incomprehensible to me. I assume the code below is right,
-            #       because in my eyes it makes the most sense.
+            #       incomprehensible to me.
+            # NOTE: there might be another way of performing this operation, 
+            #       namely:
+            #       https://discuss.pytorch.org/t/proper-way-of-setting-h-c-in-bidirectional-rnn-layers/158842
             hidden = torch.cat([hidden, reverse_hidden], dim=0)
             cell = torch.cat([cell, reverse_cell], dim=0)
 
@@ -508,14 +510,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         # NOTE: to reviewer: see above. The process is not extremely clear from
         #       the pytorch documentation
         if self.hparams.bidirectional_lstm_decoder:
-            # decoder_output = decoder_output.view(-1, decoder_lengths, 2, self.hparams.hidden_size)[:, :, 0, :]
             decoder_output = decoder_output[:, :, :self.hparams.hidden_size]
-
-        
-        # print(encoder_output.shape)
-        # print(embeddings_varying_encoder.shape)
-        # print(decoder_output.shape)
-        # print(embeddings_varying_decoder.shape)
 
         # skip connection over lstm
         lstm_output_encoder = self.post_lstm_gate_encoder(encoder_output)

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -47,6 +47,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         x_categoricals: List[str] = [],
         hidden_continuous_size: int = 8,
         hidden_continuous_sizes: Dict[str, int] = {},
+        bidirectional_lstm_decoder: bool = False,
         embedding_sizes: Dict[str, Tuple[int, int]] = {},
         embedding_paddings: List[str] = [],
         embedding_labels: Dict[str, np.ndarray] = {},
@@ -109,6 +110,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
                 embedding size)
             hidden_continuous_sizes: dictionary mapping continuous input indices to sizes for variable selection
                 (fallback to hidden_continuous_size if index is not in dictionary)
+            bidirectional_lstm_decoder: whether the lstm decoder should be a bidirectional layer or not
             embedding_sizes: dictionary mapping (string) indices to tuple of number of categorical classes and
                 embedding size
             embedding_paddings: list of indices for embeddings which transform the zero's embedding to a zero vector
@@ -288,6 +290,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             num_layers=self.hparams.lstm_layers,
             dropout=self.hparams.dropout if self.hparams.lstm_layers > 1 else 0,
             batch_first=True,
+            bidirectional=self.hparams.bidirectional_lstm_decoder,
         )
 
         # skip connection for lstm

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -45,6 +45,10 @@ def test_non_causal_attention(dataloaders_with_covariates, tmp_path, gpus):
     _integration(dataloaders_with_covariates, tmp_path, gpus, causal_attention=False, loss=TweedieLoss())
 
 
+def test_bidirectional_decoder(dataloaders_with_covariates, tmp_path, gpus):
+    _integration(dataloaders_with_covariates, tmp_path, gpus, bidirectional_lstm_decoder=True)
+
+
 def test_distribution_loss(data_with_covariates, tmp_path, gpus):
     data_with_covariates = data_with_covariates.assign(volume=lambda x: x.volume.round())
     dataloaders_with_covariates = make_dataloaders(


### PR DESCRIPTION
### Description

This feature implements the possibility of using bidirectional lstm decoder layers in the Temporal Fusion Transformer model. There are some additional notes in the code, which should be considered during code review.

### Checklist

- [x] Linked issues (if existing)
No existing issues, but possible caveats:
https://discuss.pytorch.org/t/proper-way-of-setting-h-c-in-bidirectional-rnn-layers/158842
- [x] Amended changelog for large changes (and added myself there as contributor)
Changes too small to be of significance in a changelog (i.m.o.)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
