### PR TITLE
Fix dtype check

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -254,7 +254,9 @@ class NaNLabelEncoder(InitialParameterRepresenterMixIn, BaseEstimator, Transform
         Returns:
             bool: True if series is numeric
         """
-        return y.dtype.kind in "bcif" or (isinstance(y, pd.CategoricalDtype) and y.cat.categories.dtype.kind in "bcif")
+        return y.dtype.kind in "bcif" or (
+            isinstance(y.dtype, pd.CategoricalDtype) and y.cat.categories.dtype.kind in "bcif"
+        )
 
     def fit(self, y: pd.Series, overwrite: bool = False):
         """


### PR DESCRIPTION
### Description

This PR fixes the dtype check in `is_numeric`. Currently, it will always evaluate to `pandas.core.series.Series` and never a categorical type as we are checking the `type` of the series that is passed in. This modifies to check if the dtype is categorical, which I think is the desired usage.

### Checklist

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
