### PR TITLE
Avoid attribute errors with 3rd-party loggers

### DIFF
--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy.lib.function_base import iterable
 import pandas as pd
 from pytorch_lightning import LightningModule
+from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.trainer.states import RunningStage
 from pytorch_lightning.utilities.parsing import AttributeDict, get_init_args
 import scipy.stats
@@ -722,12 +723,13 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     tag += f" of item {idx} in batch {batch_idx}"
                 if isinstance(fig, (list, tuple)):
                     for idx, f in enumerate(fig):
-                        self.logger.experiment.add_figure(
-                            f"{self.target_names[idx]} {tag}",
-                            f,
-                            global_step=self.global_step,
-                        )
-                else:
+                        if isinstance(self.logger, TensorBoardLogger):
+                            self.logger.experiment.add_figure(
+                                f"{self.target_names[idx]} {tag}",
+                                f,
+                                global_step=self.global_step,
+                            )
+                elif isinstance(self.logger, TensorBoardLogger):
                     self.logger.experiment.add_figure(
                         tag,
                         fig,
@@ -883,7 +885,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         ax.set_ylabel("Average gradient")
         ax.set_yscale("log")
         ax.set_title("Gradient flow")
-        self.logger.experiment.add_figure("Gradient flow", fig, global_step=self.global_step)
+        if isinstance(self.logger, TensorBoardLogger):
+            self.logger.experiment.add_figure("Gradient flow", fig, global_step=self.global_step)
 
     def on_after_backward(self):
         """

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -4,6 +4,7 @@ N-Beats model for timeseries forecasting without covariates.
 from typing import Dict, List
 
 import matplotlib.pyplot as plt
+from pytorch_lightning.loggers import TensorBoardLogger
 import torch
 from torch import nn
 
@@ -12,7 +13,6 @@ from pytorch_forecasting.data.encoders import NaNLabelEncoder
 from pytorch_forecasting.metrics import MAE, MAPE, MASE, RMSE, SMAPE, MultiHorizonMetric
 from pytorch_forecasting.models.base_model import BaseModel
 from pytorch_forecasting.models.nbeats.sub_modules import NBEATSGenericBlock, NBEATSSeasonalBlock, NBEATSTrendBlock
-from pytorch_lightning.loggers import TensorBoardLogger
 
 
 class NBeats(BaseModel):

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -12,6 +12,7 @@ from pytorch_forecasting.data.encoders import NaNLabelEncoder
 from pytorch_forecasting.metrics import MAE, MAPE, MASE, RMSE, SMAPE, MultiHorizonMetric
 from pytorch_forecasting.models.base_model import BaseModel
 from pytorch_forecasting.models.nbeats.sub_modules import NBEATSGenericBlock, NBEATSSeasonalBlock, NBEATSTrendBlock
+from pytorch_lightning.loggers import TensorBoardLogger
 
 
 class NBeats(BaseModel):
@@ -270,7 +271,8 @@ class NBeats(BaseModel):
                 name += f"step {self.global_step}"
             else:
                 name += f"batch {batch_idx}"
-            self.logger.experiment.add_figure(name, fig, global_step=self.global_step)
+            if isinstance(self.logger, TensorBoardLogger):
+                self.logger.experiment.add_figure(name, fig, global_step=self.global_step)
 
     def plot_interpretation(
         self,

--- a/pytorch_forecasting/models/nhits/__init__.py
+++ b/pytorch_forecasting/models/nhits/__init__.py
@@ -16,6 +16,7 @@ from pytorch_forecasting.models.base_model import BaseModelWithCovariates
 from pytorch_forecasting.models.nhits.sub_modules import NHiTS as NHiTSModule
 from pytorch_forecasting.models.nn.embeddings import MultiEmbedding
 from pytorch_forecasting.utils import create_mask, detach, to_list
+from pytorch_lightning.loggers import TensorBoardLogger
 
 
 class NHiTS(BaseModelWithCovariates):
@@ -523,17 +524,20 @@ class NHiTS(BaseModelWithCovariates):
                 name += f"step {self.global_step}"
             else:
                 name += f"batch {batch_idx}"
-            self.logger.experiment.add_figure(name, fig, global_step=self.global_step)
+            if isinstance(self.logger, TensorBoardLogger):
+                self.logger.experiment.add_figure(name, fig, global_step=self.global_step)
             if isinstance(fig, (list, tuple)):
                 for idx, f in enumerate(fig):
-                    self.logger.experiment.add_figure(
-                        f"{self.target_names[idx]} {name}",
-                        f,
-                        global_step=self.global_step,
-                    )
+                    if isinstance(self.logger, TensorBoardLogger):
+                        self.logger.experiment.add_figure(
+                            f"{self.target_names[idx]} {name}",
+                            f,
+                            global_step=self.global_step,
+                        )
                 else:
-                    self.logger.experiment.add_figure(
-                        name,
-                        fig,
-                        global_step=self.global_step,
-                    )
+                    if isinstance(self.logger, TensorBoardLogger):
+                        self.logger.experiment.add_figure(
+                            name,
+                            fig,
+                            global_step=self.global_step,
+                        )

--- a/pytorch_forecasting/models/nhits/__init__.py
+++ b/pytorch_forecasting/models/nhits/__init__.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from matplotlib import pyplot as plt
 import numpy as np
+from pytorch_lightning.loggers import TensorBoardLogger
 import torch
 from torch import nn
 
@@ -16,7 +17,6 @@ from pytorch_forecasting.models.base_model import BaseModelWithCovariates
 from pytorch_forecasting.models.nhits.sub_modules import NHiTS as NHiTSModule
 from pytorch_forecasting.models.nn.embeddings import MultiEmbedding
 from pytorch_forecasting.utils import create_mask, detach, to_list
-from pytorch_lightning.loggers import TensorBoardLogger
 
 
 class NHiTS(BaseModelWithCovariates):

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Tuple, Union
 
 from matplotlib import pyplot as plt
 import numpy as np
+from pytorch_lightning.loggers import TensorBoardLogger
 import torch
 from torch import nn
 from torchmetrics import Metric as LightningMetric
@@ -24,7 +25,6 @@ from pytorch_forecasting.models.temporal_fusion_transformer.sub_modules import (
     VariableSelectionNetwork,
 )
 from pytorch_forecasting.utils import create_mask, detach, integer_histogram, masked_op, padded_stack, to_list
-from pytorch_lightning.loggers import TensorBoardLogger
 
 
 class TemporalFusionTransformer(BaseModelWithCovariates):

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -24,6 +24,7 @@ from pytorch_forecasting.models.temporal_fusion_transformer.sub_modules import (
     VariableSelectionNetwork,
 )
 from pytorch_forecasting.utils import create_mask, detach, integer_histogram, masked_op, padded_stack, to_list
+from pytorch_lightning.loggers import TensorBoardLogger
 
 
 class TemporalFusionTransformer(BaseModelWithCovariates):
@@ -817,9 +818,10 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         label = self.current_stage
         # log to tensorboard
         for name, fig in figs.items():
-            self.logger.experiment.add_figure(
-                f"{label.capitalize()} {name} importance", fig, global_step=self.global_step
-            )
+            if isinstance(self.logger, TensorBoardLogger):
+                self.logger.experiment.add_figure(
+                    f"{label.capitalize()} {name} importance", fig, global_step=self.global_step
+                )
 
         # log lengths of encoder/decoder
         for type in ["encoder", "decoder"]:
@@ -839,9 +841,10 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             ax.set_ylabel("Number of samples")
             ax.set_title(f"{type.capitalize()} length distribution in {label} epoch")
 
-            self.logger.experiment.add_figure(
-                f"{label.capitalize()} {type} length distribution", fig, global_step=self.global_step
-            )
+            if isinstance(self.logger, TensorBoardLogger):
+                self.logger.experiment.add_figure(
+                    f"{label.capitalize()} {type} length distribution", fig, global_step=self.global_step
+                )
 
     def log_embeddings(self):
         """


### PR DESCRIPTION
### Description

This PR fixes https://github.com/Lightning-AI/lightning/issues/14723
Fixes #983

This fix avoids attribute error when logging the figures with 3rd-party loggers. Later on, one could add support for logging the figures with the other frameworks as well, as proposed in #89. 

### Checklist

- [x] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
