### PR TITLE
Fix robust scaler - move to quantiles instead of kthvalue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v0.10.4 UNRELEASED (xx/xx/xxxx)
+
+### Fixed
+
+- Fixed robust scaler when quantiles are 0.0, and 1.0, i.e. minimum and maximum (#1142)
+
 ## v0.10.3 Poetry update (07/09/2022)
 
 ### Fixed

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -6,6 +6,12 @@
   flex-grow: 1;
   max-width: 100%;
 }
+.bd-page-width {
+  max-width: 100rem;
+}
+.bd-main .bd-content .bd-article-container {
+  max-width: 100%;
+}
 
 a.reference.internal.nav-link {
   color: #727991 !important;

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -501,11 +501,9 @@ class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, Transform
 
         elif self.method == "robust":
             if isinstance(y_center, torch.Tensor):
-                self.center_ = y_center.kthvalue(
-                    int(len(y_center) * self.method_kwargs.get("center", 0.5)), dim=-1
-                ).values
-                q_75 = y_scale.kthvalue(int(len(y_scale) * self.method_kwargs.get("upper", 0.75)), dim=-1).values
-                q_25 = y_scale.kthvalue(int(len(y_scale) * self.method_kwargs.get("lower", 0.25)), dim=-1).values
+                self.center_ = y_center.quantile(self.method_kwargs.get("center", 0.5), dim=-1)
+                q_75 = y_scale.quantile(self.method_kwargs.get("upper", 0.75), dim=-1)
+                q_25 = y_scale.quantile(self.method_kwargs.get("lower", 0.25), dim=-1)
             elif isinstance(y_center, np.ndarray):
                 self.center_ = np.percentile(y_center, self.method_kwargs.get("center", 0.5) * 100, axis=-1)
                 q_75 = np.percentile(y_scale, self.method_kwargs.get("upper", 0.75) * 100, axis=-1)

--- a/tests/test_data/test_encoders.py
+++ b/tests/test_data/test_encoders.py
@@ -55,6 +55,7 @@ def test_NaNLabelEncoder_add():
     "kwargs",
     [
         dict(method="robust"),
+        dict(method="robust", method_kwargs=dict(upper=1.0, lower=0.0)),
         dict(method="robust", data=np.random.randn(100)),
         dict(data=np.random.randn(100)),
         dict(transformation="log"),


### PR DESCRIPTION
### Description

This PR fixes robust scaling

### Checklist

- [x] Amended changelog for large changes (and added myself there as contributor)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
