### PR TITLE
Add some tests against simple mistakes in min_encoder_length and time_idx series

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -333,8 +333,9 @@ class TimeSeriesDataSet(Dataset):
         if min_encoder_length is None:
             min_encoder_length = max_encoder_length
         self.min_encoder_length = min_encoder_length
+        assert self.min_encoder_length > 0, "min encoder length must be larger than 0"
         assert (
-            self.min_encoder_length <= self.max_encoder_length
+                self.min_encoder_length <= self.max_encoder_length
         ), "max encoder length has to be larger equals min encoder length"
         assert isinstance(self.min_encoder_length, int), "min encoder length must be integer"
         self.max_prediction_length = max_prediction_length
@@ -343,11 +344,12 @@ class TimeSeriesDataSet(Dataset):
             min_prediction_length = max_prediction_length
         self.min_prediction_length = min_prediction_length
         assert (
-            self.min_prediction_length <= self.max_prediction_length
+                self.min_prediction_length <= self.max_prediction_length
         ), "max prediction length has to be larger equals min prediction length"
         assert self.min_prediction_length > 0, "min prediction length must be larger than 0"
         assert isinstance(self.min_prediction_length, int), "min prediction length must be integer"
         assert data[time_idx].dtype.kind == "i", "Timeseries index should be of type integer"
+        assert len(data[time_idx].unique()) > 1, "Timeseries index should contain various values"
         self.target = target
         self.weight = weight
         self.time_idx = time_idx

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -335,7 +335,7 @@ class TimeSeriesDataSet(Dataset):
         self.min_encoder_length = min_encoder_length
         assert self.min_encoder_length > 0, "min encoder length must be larger than 0"
         assert (
-                self.min_encoder_length <= self.max_encoder_length
+            self.min_encoder_length <= self.max_encoder_length
         ), "max encoder length has to be larger equals min encoder length"
         assert isinstance(self.min_encoder_length, int), "min encoder length must be integer"
         self.max_prediction_length = max_prediction_length
@@ -344,7 +344,7 @@ class TimeSeriesDataSet(Dataset):
             min_prediction_length = max_prediction_length
         self.min_prediction_length = min_prediction_length
         assert (
-                self.min_prediction_length <= self.max_prediction_length
+            self.min_prediction_length <= self.max_prediction_length
         ), "max prediction length has to be larger equals min prediction length"
         assert self.min_prediction_length > 0, "min prediction length must be larger than 0"
         assert isinstance(self.min_prediction_length, int), "min prediction length must be integer"


### PR DESCRIPTION
### Description

This PR adds obvious checks for input parameters. Keeping min_encoder_length with availability to set 0 will be reason of error in making attention plot which can be hardly connected without debugging. 

> ValueError: x and y must have same first dimension, but have shapes torch.Size([0]) and torch.Size([1])

### Checklist

- [ ] Linked issues (if existing) 

- AssertionError: filters should not remove entries all entries - check encoder/decoder lengths and lags #584

