### PR TITLE
Issue when optim lr find

### DIFF
--- a/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
@@ -133,8 +133,9 @@ def optimize_hyperparameters(
         logger = TensorBoardLogger(log_dir, name="optuna", version=trial.number)
         gradient_clip_val = trial.suggest_loguniform("gradient_clip_val", *gradient_clip_val_range)
         default_trainer_kwargs = dict(
-            gpus=[0] if torch.cuda.is_available() else None,
+            accelerator="gpu", devices=-1, auto_select_gpus=True if torch.cuda.is_available() else None,
             max_epochs=max_epochs,
+            auto_scale_batch_size="binsearch",
             gradient_clip_val=gradient_clip_val,
             callbacks=[
                 metrics_callback,
@@ -172,8 +173,9 @@ def optimize_hyperparameters(
         if use_learning_rate_finder:
             lr_trainer = pl.Trainer(
                 gradient_clip_val=gradient_clip_val,
-                gpus=[0] if torch.cuda.is_available() else None,
+                accelerator="gpu", devices=-1, auto_select_gpus=True if torch.cuda.is_available() else None,
                 logger=False,
+                auto_scale_batch_size="binsearch",
                 enable_progress_bar=False,
                 enable_model_summary=False,
             )

--- a/pytorch_forecasting/optim.py
+++ b/pytorch_forecasting/optim.py
@@ -130,10 +130,10 @@ class Ranger(Optimizer):
 
     def __setstate__(self, state: dict) -> None:
         super().__setstate__(state)
-        self.radam_buffer = state["radam_buffer"]
-        self.alpha = state["alpha"]
-        self.k = state["k"]
-        self.N_sma_threshhold = state["N_sma_threshhold"]
+        self.radam_buffer = state['state']["radam_buffer"]
+        self.alpha = state['state']["alpha"]
+        self.k = state['state']["k"]
+        self.N_sma_threshhold = state['state']["N_sma_threshhold"]
 
     def step(self, closure: OptLossClosure = None) -> OptFloat:
         r"""Performs a single optimization step.


### PR DESCRIPTION
### Description

Working with this model, when I launch the code to find the optimal learning rate. It gives an error Keyerror: 'radam_buffer', it is because it tries to find a value that is not in the state list, but in state['state'].

Piece of code show error.
```
# find optimal learning rate
res = trainer.tuner.lr_find(
    tft,
    train_dataloaders=train_dataloader,
    val_dataloaders=val_dataloader,
    max_lr=10.0,
    min_lr=1e-6,
)

print(f"suggested learning rate: {res.suggestion()}")
fig = res.plot(show=True, suggest=True)
fig.show()
```

### Checklist

- [x] [Linked issues (if existing)](https://github.com/jdb78/pytorch-forecasting/issues/928#issuecomment-1256432343)
- [x] Amended changelog for large changes (and added myself there as contributor)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

