### PR TITLE
optim.py defaultdict, __setstate__

### DIFF
--- a/pytorch_forecasting/optim.py
+++ b/pytorch_forecasting/optim.py
@@ -86,6 +86,7 @@ class Ranger(Optimizer):
             N_sma_threshhold=N_sma_threshhold,
             eps=eps,
             weight_decay=weight_decay,
+            radam_buffer = [[None, None, None] for ind in range(10)] # radam_buffer needs to be set to in defaults for it to updated in state dict
         )
         super().__init__(params, defaults)
 
@@ -130,6 +131,9 @@ class Ranger(Optimizer):
 
     def __setstate__(self, state: dict) -> None:
         super().__setstate__(state)
+        # print(state['state'])
+        # print(state['param_groups'][0].keys())
+        state = state['param_groups'][0]
         self.radam_buffer = state["radam_buffer"]
         self.alpha = state["alpha"]
         self.k = state["k"]


### PR DESCRIPTION
added radam_buffer in default dict -- line 89

modified __setstate__ method to properly retrieve state dict -- lines (134-136)

code with changes reproduced here on stallion TFT model

### Description

This PR is to make changes to the "optim.py" file, the ranger optimizer, which is causing the issue [1233](https://github.com/jdb78/pytorch-forecasting/issues/1233)

### Checklist

- [x] Linked issues [1233](https://github.com/jdb78/pytorch-forecasting/issues/1233)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
