### PR TITLE
Pass y as arg instead of karg, so it will work with scikit-learn wrap

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -956,7 +956,7 @@ class GroupNormalizer(TorchNormalizer):
         if target_scale is None:
             assert X is not None, "either target_scale or X has to be passed"
             target_scale = self.get_norm(X)
-        return super().transform(y=y, return_norm=return_norm, target_scale=target_scale)
+        return super().transform(y, return_norm=return_norm, target_scale=target_scale)
 
     def get_parameters(self, groups: Union[torch.Tensor, list, tuple], group_names: List[str] = None) -> np.ndarray:
         """


### PR DESCRIPTION
### Description

This PR fixes #1246.

Seems that sklearn wrap from function _wrap_method_output in sklearn/utils/_set_output.py always requires a X as *arg. If we pass y as an *arg instead of a **karg, it seems that the GroupNormalizer can work as expected.

### Checklist

- [x] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
