### PR TITLE
'encoder_features' referenced before assignment

### DIFF
--- a/pytorch_forecasting/models/nhits/__init__.py
+++ b/pytorch_forecasting/models/nhits/__init__.py
@@ -253,6 +253,7 @@ class NHiTS(BaseModelWithCovariates):
 
         # statics
         if self.static_size > 0:
+            encoder_features = self.extract_features(x, self.embeddings, period="all")
             x_s = torch.concat([encoder_features[name][:, 0] for name in self.static_variables], dim=1)
         else:
             x_s = None


### PR DESCRIPTION
the static covariate should be extracted first before referenced in line 256.

### Description


### Checklist

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
