### PR TITLE
Multiple Target Prediction Plotting Bug

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -414,7 +414,7 @@ class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, Transform
 
                 * None (default): No transformation of values
                 * log: Estimate in log-space leading to a multiplicative model
-                * logp1: Estimate in log-space but add 1 to values before transforming for stability
+                * log1p: Estimate in log-space but add 1 to values before transforming for stability
                   (e.g. if many small values <<1 are present).
                   Note, that inverse transform is still only `torch.exp()` and not `torch.expm1()`.
                 * logit: Apply logit transformation on values that are between 0 and 1
@@ -646,7 +646,7 @@ class EncoderNormalizer(TorchNormalizer):
 
                 * None (default): No transformation of values
                 * log: Estimate in log-space leading to a multiplicative model
-                * logp1: Estimate in log-space but add 1 to values before transforming for stability
+                * log1p: Estimate in log-space but add 1 to values before transforming for stability
                     (e.g. if many small values <<1 are present).
                     Note, that inverse transform is still only `torch.exp()` and not `torch.expm1()`.
                 * logit: Apply logit transformation on values that are between 0 and 1
@@ -753,7 +753,7 @@ class GroupNormalizer(TorchNormalizer):
 
                 * None (default): No transformation of values
                 * log: Estimate in log-space leading to a multiplicative model
-                * logp1: Estimate in log-space but add 1 to values before transforming for stability
+                * log1p: Estimate in log-space but add 1 to values before transforming for stability
                     (e.g. if many small values <<1 are present).
                     Note, that inverse transform is still only `torch.exp()` and not `torch.expm1()`.
                 * logit: Apply logit transformation on values that are between 0 and 1

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -993,6 +993,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
         # for each target, plot
         figs = []
+        ax_provided = ax is not None
         for y_raw, y_hat, y_quantile, encoder_target, decoder_target in zip(
             y_raws, y_hats, y_quantiles, encoder_targets, decoder_targets
         ):
@@ -1012,7 +1013,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
             # move to cpu
             y = y.detach().cpu()
             # create figure
-            if ax is None:
+            if (ax is None) or (not ax_provided):
                 fig, ax = plt.subplots()
             else:
                 fig = ax.get_figure()


### PR DESCRIPTION

### Description
When calling the plot_prediction() function in PytorchForecasting with multiple targets, the function reuses the same axes for each target. This behavior results in overlapped plots for different targets, rather than separate plots for each target.
This pull request fixes this issue.

### Issue
#1314 

### The faulty code part
```
def plot_prediction(
    self,
    x: Dict[str, torch.Tensor],
    out: Dict[str, torch.Tensor],
    idx: int = 0,
    add_loss_to_title: Union[Metric, torch.Tensor, bool] = False,
    show_future_observed: bool = True,
    ax=None,
    quantiles_kwargs: Dict[str, Any] = {},
    prediction_kwargs: Dict[str, Any] = {},
) -> plt.Figure:

    #...

    # for each target, plot
    figs = []
    for y_raw, y_hat, y_quantile, encoder_target, decoder_target in zip(
        y_raws, y_hats, y_quantiles, encoder_targets, decoder_targets
    ):
        # ...

        # create figure
        if ax is None:
            fig, ax = plt.subplots()
        else:
            fig = ax.get_figure()
        
        # ...

        figs.append(fig)
    
    return figs
```

_Expected behavior:_
Each target should be plotted on a separate figure.

_Actual behavior:_
All targets are plotted on the same figure, resulting in overlapped plots.

### Solution
In the above snippet, the variable ax should be updated within the loop over targets but instead after the first target, the same ax is reused (as ax is no longer None). The proposed issue fix is:

```
    def plot_prediction(
        self,
        x: Dict[str, torch.Tensor],
        out: Dict[str, torch.Tensor],
        idx: int = 0,
        add_loss_to_title: Union[Metric, torch.Tensor, bool] = False,
        show_future_observed: bool = True,
        ax=None,
        quantiles_kwargs: Dict[str, Any] = {},
        prediction_kwargs: Dict[str, Any] = {},
    ) -> plt.Figure:

        # ...
        # for each target, plot
        figs = []
        ax_provided = ax is not None
        for y_raw, y_hat, y_quantile, encoder_target, decoder_target in zip(
            y_raws, y_hats, y_quantiles, encoder_targets, decoder_targets
        ):

            # ...
            # create figure
            if (ax is None) or (not ax_provided):
                fig, ax = plt.subplots()
            else:
                fig = ax.get_figure()
```

### Bonus
Corrected mistakes in documentation. The encoder's `log1p` transformation is incorrectly called `logp1` in the documentation.
#1247 

