### PR TITLE
Bugfix, weights shape during length randomization

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1559,6 +1559,8 @@ class TimeSeriesDataSet(Dataset):
                 data_cat = data_cat[encoder_length - new_encoder_length : encoder_length + new_decoder_length]
                 data_cont = data_cont[encoder_length - new_encoder_length : encoder_length + new_decoder_length]
                 target = [t[encoder_length - new_encoder_length : encoder_length + new_decoder_length] for t in target]
+                if weight:
+                    weight = weight[encoder_length - new_encoder_length : encoder_length + new_decoder_length]
                 encoder_length = new_encoder_length
                 decoder_length = new_decoder_length
 

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1559,7 +1559,7 @@ class TimeSeriesDataSet(Dataset):
                 data_cat = data_cat[encoder_length - new_encoder_length : encoder_length + new_decoder_length]
                 data_cont = data_cont[encoder_length - new_encoder_length : encoder_length + new_decoder_length]
                 target = [t[encoder_length - new_encoder_length : encoder_length + new_decoder_length] for t in target]
-                if weight:
+                if weight is not None:
                     weight = weight[encoder_length - new_encoder_length : encoder_length + new_decoder_length]
                 encoder_length = new_encoder_length
                 decoder_length = new_decoder_length


### PR DESCRIPTION
### Description

This PR fixes RuntimeError during calculation of weighted MultiHorizonMetric loss due to losses and weights shape mismatch.

#### Setup
```
training_dataset = TimeSeriesDataSet(
    dataset.loc[dataset["date"] <= cutoff_],
    time_idx="time_idx",
    target="target",
    weight="weight",
    group_ids=["group_id_1", "group_id_2", "group_id_3"],
    min_encoder_length=max_encoder_length // 2,
    max_encoder_length=max_encoder_length,
    min_prediction_length=1,
    max_prediction_length=max_prediction_length,
    static_categoricals=static_categoricals,
    time_varying_known_reals=time_varying_known_reals,
    time_varying_known_categoricals=time_varying_known_categoricals,
    time_varying_unknown_reals=time_varying_unknown_reals,
    target_normalizer=target_normalizer,
    categorical_encoders=categorical_encoders,
    scalers=scalers,
    add_relative_time_idx=True,
    add_encoder_length=True,
    randomize_length=(0.1, 0.15),
    allow_missing_timesteps=False,
)

tft = TemporalFusionTransformer.from_dataset(
    training_dataset,
    learning_rate=0.0001,
    hidden_size=256,
    lstm_layers=2,
    attention_head_size=4,
    dropout=0.5,
    hidden_continuous_size=128,
    output_size=7,
    loss=QuantileLoss(),
    reduce_on_plateau_patience=4,
)
```

#### Error
```
File /opt/conda/envs/forecaster-env/lib/python3.9/site-packages/pytorch-forecasting/pytorch_forecsting/metrics/base_metrics.py in MultiHorizonMetric.update(self, y_pred, target)
     786   if weight is not None:
---> 787       losses = losses * unsqueeze_like(weight, losses)
     789   self._update_losses_and_lengths(losses, lengths)

RuntimeError: The size of tensor a (12) must match the size of tensor b (22) at non-singleton dimension 1
```

### Issues
Possible linked issues (they have exact same error, but different setup) 
- #942 
- #1099
