### PR TITLE
Bugfix: handle case where 'losses' is a list of tensors

### DIFF
--- a/pytorch_forecasting/metrics/base_metrics.py
+++ b/pytorch_forecasting/metrics/base_metrics.py
@@ -822,6 +822,9 @@ class MultiHorizonMetric(Metric):
         """
         if reduction is None:
             reduction = self.reduction
+
+        if isinstance(losses, list): losses = losses[0]
+
         if losses.ndim > 0:
             # mask loss
             mask = torch.arange(losses.size(1), device=losses.device).unsqueeze(0) >= lengths.unsqueeze(-1)


### PR DESCRIPTION
### Description

This PR fixes an issue I came across when applying NHiTS and TFT on my use case, namely that `losses` can be tensors within a list. In that case, the function `mask_losses` will fail. It is just a one-liner in **base_metrics.py**.
