### PR TITLE
Fix error when handing over trainer_kwargs to predict_depency()

### DIFF
--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -1473,13 +1473,14 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
             # set values
             data.set_overwrite_values(variable=variable, values=value, target=target)
             # predict
-            kwargs.setdefault("mode", "prediction")
+            pred_kwargs = deepcopy(kwargs)
+            pred_kwargs.setdefault("mode", "prediction")
 
             if idx == 0 and mode == "dataframe":  # need index for returning as dataframe
-                res = self.predict(data, return_index=True, **kwargs)
+                res = self.predict(data, return_index=True, **pred_kwargs)
                 results.append(res.output)
             else:
-                results.append(self.predict(data, **kwargs))
+                results.append(self.predict(data, **pred_kwargs))
             # increment progress
             progress_bar.update()
 


### PR DESCRIPTION
### Description

This PR fixes an error when handing over `trainer_kwargs` to `predict_dependency()`, as in the following example:

```
model.predict_dependency(ds, "feature", np.linspace(0, 30, 30), mode="dataframe",  trainer_kwargs={ "accelerator": "cpu"})
```

Overwriting `trainer_kwargs` might be necessary when using a model trained on GPU. The issue comes from the `kwargs` dict handed over to `predict_dependency()` being overwritten in `predict()`, which will cause it to contain a `PredictCallback(return_index=True, ...)` in the `kwargs["trainer_kwargs"]["callbacks"]` list, even in the second iteration where `return_index` should be `False`, causing a subsequent error 

```
File ~/Library/Caches/pypoetry/virtualenvs/discovery-lab-rTrwb4a5-py3.10/lib/python3.10/site-packages/pytorch_forecasting/models/base_model.py:1491, in BaseModel.predict_dependency(self, data, variable, values, mode, target, show_progress_bar, **kwargs)
   1488 data.reset_overwrite_values()  # reset overwrite values to avoid side-effect
   1490 # results to one tensor
-> 1491 results = torch.stack(results, dim=0)
   1493 # convert results to requested output format
   1494 if mode == "series":

TypeError: expected Tensor as element 1 in argument 0, but got list
```

This PR fixes this by copying the user-specified `kwargs` in every iteration. No tests have been added, as this is a very minor change.

### Checklist

- [x] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
