### PR TITLE
readme: fix linter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [conda-url]: https://anaconda.org/conda-forge/pytorch-forecasting
 [build-image]: https://github.com/jdb78/pytorch-forecasting/actions/workflows/test.yml/badge.svg?branch=master
 [build-url]: https://github.com/jdb78/pytorch-forecasting/actions/workflows/test.yml?query=branch%3Amaster
-[linter-image]: https://github.com/jdb78/pytorch-forecasting/actions/workflows/code_quality.yml/badge.svg?branch=master
+[linter-image]: https://github.com/jdb78/pytorch-forecasting/actions/workflows/lint.yml/badge.svg?event=push
 [linter-url]: https://github.com/jdb78/pytorch-forecasting/actions/workflows/code_quality.yml?query=branch%3Amaster
 [docs-image]: https://readthedocs.org/projects/pytorch-forecasting/badge/?version=latest
 [docs-url]: https://pytorch-forecasting.readthedocs.io


### PR DESCRIPTION
### Description

It seems that the workflow was renamed, so the badge is wrong:
- actual -> ![](https://github.com/jdb78/pytorch-forecasting/actions/workflows/code_quality.yml/badge.svg?branch=master)
- fixed -> ![](https://github.com/jdb78/pytorch-forecasting/actions/workflows/lint.yml/badge.svg?event=push)
 

### Checklist

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!

cc: @jdb78 