### PR TITLE
Bugfix: if infite loss is detected, error will be thrown during the backpropogation

### DIFF
--- a/pytorch_forecasting/metrics/base_metrics.py
+++ b/pytorch_forecasting/metrics/base_metrics.py
@@ -799,7 +799,7 @@ class MultiHorizonMetric(Metric):
         else:
             losses = losses.sum()
             if not torch.isfinite(losses):
-                losses = torch.tensor(1e9, device=losses.device)
+                losses = losses.fill_(1e9)
                 warnings.warn("Loss is not finite. Resetting it to 1e9")
             self.losses = self.losses + losses
             self.lengths = self.lengths + lengths.sum()


### PR DESCRIPTION
infinite loss bug fixed

### Description

The bug is described here: https://lightning.ai/forums/t/why-does-training-fails-with-require-grad-and-does-not-have-a-grad-fn/2782

If loss is not finite, the following error will be thrown:
```
require grad and does not have a grad_fn
```

This bug was reproduced by me and proposed fix is checked bu me as well.