### PR TITLE
Allow mixed precision TFT training

### DIFF
--- a/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
@@ -388,7 +388,7 @@ class ScaledDotProductAttention(nn.Module):
             attn = attn / dimension
 
         if mask is not None:
-            attn = attn.masked_fill(mask, -1e9)
+            attn = attn.masked_fill(mask, -float("inf"))
         attn = self.softmax(attn)
 
         if self.dropout is not None:


### PR DESCRIPTION
### Description

This PR modifies the attention mask in the TFT model from 1e-9 to float("inf") to allow Pytorch mixed precision training.

Related issues: 
#1325
#285 