### PR TITLE
[MNT] update nbeats/sub_modules.py to remove overhead in tensor creation

### DIFF
--- a/pytorch_forecasting/models/nbeats/sub_modules.py
+++ b/pytorch_forecasting/models/nbeats/sub_modules.py
@@ -111,45 +111,21 @@ class NBEATSSeasonalBlock(NBEATSBlock):
             else (thetas_dim // 2, thetas_dim // 2 + 1)
         )
         s1_b = torch.tensor(
-            np.array(
-                [
-                    np.cos(2 * np.pi * i * backcast_linspace)
-                    for i in self.get_frequencies(p1)
-                ],
-                dtype=np.float32,
-            ),
+            np.cos(2 * np.pi * self.get_frequencies(p1)[:, None] * backcast_linspace),
             dtype=torch.float32,
         )  # H/2-1
         s2_b = torch.tensor(
-            np.array(
-                [
-                    np.sin(2 * np.pi * i * backcast_linspace)
-                    for i in self.get_frequencies(p2)
-                ],
-                dtype=np.float32,
-            ),
+            np.sin(2 * np.pi * self.get_frequencies(p2)[:, None] * backcast_linspace),
             dtype=torch.float32,
         )
         self.register_buffer("S_backcast", torch.cat([s1_b, s2_b]))
 
         s1_f = torch.tensor(
-            np.array(
-                [
-                    np.cos(2 * np.pi * i * forecast_linspace)
-                    for i in self.get_frequencies(p1)
-                ],
-                dtype=np.float32,
-            ),
+            np.cos(2 * np.pi * self.get_frequencies(p1)[:, None] * forecast_linspace),
             dtype=torch.float32,
         )  # H/2-1
         s2_f = torch.tensor(
-            np.array(
-                [
-                    np.sin(2 * np.pi * i * forecast_linspace)
-                    for i in self.get_frequencies(p2)
-                ],
-                dtype=np.float32,
-            ),
+            np.sin(2 * np.pi * self.get_frequencies(p2)[:, None] * forecast_linspace),
             dtype=torch.float32,
         )
         self.register_buffer("S_forecast", torch.cat([s1_f, s2_f]))
@@ -195,18 +171,14 @@ class NBEATSTrendBlock(NBEATSBlock):
         norm = np.sqrt(
             forecast_length / thetas_dim
         )  # ensure range of predictions is comparable to input
-
+        thetas_dims_range = np.array(range(thetas_dim))
         coefficients = torch.tensor(
-            np.array(
-                [backcast_linspace**i for i in range(thetas_dim)], dtype=np.float32
-            ),
+            backcast_linspace ** thetas_dims_range[:, None],
             dtype=torch.float32,
         )
         self.register_buffer("T_backcast", coefficients * norm)
         coefficients = torch.tensor(
-            np.array(
-                [forecast_linspace**i for i in range(thetas_dim)], dtype=np.float32
-            ),
+            forecast_linspace ** thetas_dims_range[:, None],
             dtype=torch.float32,
         )
         self.register_buffer("T_forecast", coefficients * norm)


### PR DESCRIPTION
**Issue**

This PR removes a warning raised by nbeats/sub_module.py: 
`UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor.`
This commit replaces the relevant sections with the appropriate code to remove the warning in nbeats submodule. (similar to https://github.com/jdb78/pytorch-forecasting/issues/754)

**Proposed change:**

Change the implementation, as suggested by the warning to increase efficiency.