### PR TITLE
[MNT] rewrite GHA test workflow based on `pip`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     name: Run pytest
@@ -21,10 +25,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,39 +41,17 @@ jobs:
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      - name: Install poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-
-      - name: Set poetry path variable
-        run: echo "/Users/runner/.local/bin" >> $GITHUB_PATH
-
-      - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
-
-      - name: Upgrade pip
-        run: poetry run python -m pip install pip -U
-
       - name: Install dependencies
-        run: poetry install -E "github-actions graph mqf2"
+        shell: bash
+        run: |
+          pip install ".[github-actions,graph,mqf2]"
 
-      # - name: Install pytorch geometric dependencies
-      #   shell: bash
-      #   run: poetry run pip install pyg_lib torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric -f https://data.pyg.org/whl/torch-2.0.0+cpu.html
+      - name: Show dependencies
+        run: python -m pip list
 
       - name: Run pytest
-        run: poetry run pytest tests
+        shell: bash
+        run: python -m pytest tests
 
       - name: Statistics
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,51 @@ repository = "https://github.com/jdb78/pytorch-forecasting"
 documentation = "https://pytorch-forecasting.readthedocs.io"
 homepage = "https://pytorch-forecasting.readthedocs.io"
 
+dependencies = [
+  "torch >=2.0.0,!=2.0.1,<3.0.0",
+  "lightning >=2.0.0,<3.0.0",
+  "optuna >=3.1.0,<4.0.0",
+  "scipy >=1.8,<2.0",
+  "pandas >=1.3.0,<3.0.0",
+  "scikit-learn >=1.2,<2.0",
+  "matplotlib",
+  "statsmodels",
+  "pytorch-optimizer >=2.5.1,<3.0.0",
+]
+
+[project.optional-dependencies]
+
+dev = [
+  "pydocstyle >=6.1.1,<7.0.0",
+  "pre-commit >=3.2.0,<4.0.0",
+  "invoke",
+  "flake8",
+  "mypy",
+  "pylint",
+  "isort",
+  "pytest",
+  "pytest-xdist",
+  "pytest-cov",
+  "pytest-sugar",
+  "coverage",
+  "pyarrow",
+  "ipykernel",
+  "black[extras]",
+  "sphinx",
+  "pydata-sphinx-theme",
+  "nbsphinx",
+  "recommonmark",
+  "ipywidgets>=8.0.1,<9.0.0",
+  "pytest-dotenv>=0.5.2,<1.0.0",
+  "tensorboard>=2.12.1,<3.0.0",
+  "pandoc>=2.3,<3.0.0",
+]
+
+github-actions = ["pytest-github-actions-annotate-failures"]
+graph = ["networkx"]
+mqf2 = ["cpflows"]
+
+
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 


### PR DESCRIPTION
This PR rewrites the GHA test workflow to be based on `pip`.

The idea is to make it more maintainable by a larger number of contributors, by simplifying the GHA workflow, and making it uniform across packages.