### PR TITLE
[MNT] CI matrix extended to `windows-latest`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13] # add windows-2019 when poetry allows installation with `-f` flag
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.8", "3.9", "3.10"]
     defaults:
       run:


### PR DESCRIPTION
This PR extends the CI matrix to `windows-latest`, for testing windows OS compatibility.