### PR TITLE
[MNT] skip tests involved in windows failures until resolved

### DIFF
--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -376,6 +376,10 @@ def test_prediction_with_dataframe(model, data_with_covariates):
     model.predict(data_with_covariates, fast_dev_run=True)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Test skipped on Windows OS due to issues with ddp, see #1632",
+)
 @pytest.mark.parametrize("use_learning_rate_finder", [True, False])
 def test_hyperparameter_optimization_integration(dataloaders_with_covariates, tmp_path, use_learning_rate_finder):
     train_dataloader = dataloaders_with_covariates["train"]

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -245,6 +245,10 @@ def test_init_shared_network(dataloaders_with_covariates):
     net.predict(dataset, fast_dev_run=True)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('win'),
+    reason="Test skipped on Windows OS due to issues with ddp, see #1623",
+)
 @pytest.mark.parametrize("strategy", ["ddp"])
 def test_distribution(dataloaders_with_covariates, tmp_path, strategy):
     train_dataloader = dataloaders_with_covariates["train"]

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -246,7 +246,7 @@ def test_init_shared_network(dataloaders_with_covariates):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('win'),
+    sys.platform.startswith("win"),
     reason="Test skipped on Windows OS due to issues with ddp, see #1623",
 )
 @pytest.mark.parametrize("strategy", ["ddp"])


### PR DESCRIPTION
This PR skips tests involved in the failures on windows listed in #1623 until the underlying issues are resolved, see #1632 and #1632