### PR TITLE
[MNT] isolate `matplotlib` as soft dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev,all_extras,github-actions,graph,mqf2]"
+          python -m pip install ".[dev,all_extras,github-actions,graph]"
 
       - name: Show dependencies
         run:  python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev,all_extras,github-actions,graph]"
+          python -m pip install ".[dev,all_extras,github-actions,graph,mqf2]"
 
       - name: Show dependencies
         run:  python -m pip list
@@ -64,7 +64,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          pip install ".[dev,github-actions,graph,mqf2]"
+          pip install ".[dev,github-actions,graph]"
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          pip install ".[dev,github-actions,graph]"
+          pip install ".[dev,github-actions,graph,mqf2,all_extras]"
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev,github-actions,graph,mqf2]"
+          python -m pip install ".[dev,all_extras,github-actions,graph,mqf2]"
 
       - name: Show dependencies
         run:  python -m pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,15 @@ dependencies = [
   "scipy >=1.8,<2.0",
   "pandas >=1.3.0,<3.0.0",
   "scikit-learn >=1.2,<2.0",
-  "matplotlib",
   "statsmodels",
   "pytorch-optimizer >=2.5.1,<3.0.0",
 ]
 
 [project.optional-dependencies]
+
+all_extras = [
+  "matplotlib",
+]
 
 dev = [
   "pydocstyle >=6.1.1,<7.0.0",

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1357,9 +1357,7 @@ class TimeSeriesDataSet(Dataset):
         )
         return index
 
-    def plot_randomization(
-        self, betas: Tuple[float, float] = None, length: int = None, min_length: int = None
-    ):
+    def plot_randomization(self, betas: Tuple[float, float] = None, length: int = None, min_length: int = None):
         """
         Plot expected randomized length distribution.
 

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -11,7 +11,6 @@ import inspect
 from typing import Any, Callable, Dict, List, Tuple, Union
 import warnings
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import NotFittedError
@@ -32,6 +31,7 @@ from pytorch_forecasting.data.encoders import (
 )
 from pytorch_forecasting.data.samplers import TimeSynchronizedBatchSampler
 from pytorch_forecasting.utils import repr_class
+from pytorch_forecasting.utils._dependencies import _check_matplotlib
 
 
 def _find_end_indices(diffs: np.ndarray, max_lengths: np.ndarray, min_length: int) -> Tuple[np.ndarray, np.ndarray]:
@@ -1359,7 +1359,7 @@ class TimeSeriesDataSet(Dataset):
 
     def plot_randomization(
         self, betas: Tuple[float, float] = None, length: int = None, min_length: int = None
-    ) -> Tuple[plt.Figure, torch.Tensor]:
+    ):
         """
         Plot expected randomized length distribution.
 
@@ -1372,6 +1372,10 @@ class TimeSeriesDataSet(Dataset):
         Returns:
             Tuple[plt.Figure, torch.Tensor]: tuple of figure and histogram based on 1000 samples
         """
+        _check_matplotlib("plot_randomization")
+
+        import matplotlib.pyplot as plt
+
         if betas is None:
             betas = self.randomize_length
         if length is None:

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -1100,10 +1100,6 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         """
         log distribution of gradients to identify exploding / vanishing gradients
         """
-        _check_matplotlib("log_gradient_flow")
-
-        from matplotlib import pyplot as plt
-
         ave_grads = []
         layers = []
         for name, p in named_parameters:
@@ -1111,6 +1107,14 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                 layers.append(name)
                 ave_grads.append(p.grad.abs().cpu().mean())
                 self.logger.experiment.add_histogram(tag=name, values=p.grad, global_step=self.global_step)
+
+        mpl_available = _check_matplotlib("log_gradient_flow", raise_exception=False)
+
+        if not mpl_available:
+            return None
+
+        import matplotlib.pyplot as plt
+
         fig, ax = plt.subplots()
         ax.plot(ave_grads)
         ax.set_xlabel("Layers")

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -940,6 +940,12 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                 )
             else:
                 log_indices = [0]
+
+            mpl_available = _check_matplotlib("plot_prediction", raise_error=False)
+
+            if not mpl_available:
+                return None  # don't log matplotlib plots if not available
+
             for idx in log_indices:
                 fig = self.plot_prediction(x, out, idx=idx, add_loss_to_title=True, **kwargs)
                 tag = f"{self.current_stage} prediction"

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -15,7 +15,6 @@ from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.callbacks import BasePredictionWriter, LearningRateFinder
 from lightning.pytorch.trainer.states import RunningStage
 from lightning.pytorch.utilities.parsing import get_init_args
-import matplotlib.pyplot as plt
 import numpy as np
 from numpy import iterable
 import pandas as pd
@@ -55,6 +54,7 @@ from pytorch_forecasting.utils import (
     groupby_apply,
     to_list,
 )
+from pytorch_forecasting.utils._dependencies import _check_matplotlib
 
 # todo: compile models
 
@@ -971,7 +971,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         ax=None,
         quantiles_kwargs: Dict[str, Any] = {},
         prediction_kwargs: Dict[str, Any] = {},
-    ) -> plt.Figure:
+    ):
         """
         Plot prediction of prediction vs actuals
 
@@ -990,6 +990,10 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         Returns:
             matplotlib figure
         """
+        _check_matplotlib("plot_prediction")
+
+        from matplotlib import pyplot as plt
+
         # all true values for y of the first sample in batch
         encoder_targets = to_list(x["encoder_target"])
         decoder_targets = to_list(x["decoder_target"])
@@ -1096,6 +1100,10 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         """
         log distribution of gradients to identify exploding / vanishing gradients
         """
+        _check_matplotlib("log_gradient_flow")
+
+        from matplotlib import pyplot as plt
+
         ave_grads = []
         layers = []
         for name, p in named_parameters:
@@ -1842,7 +1850,7 @@ class BaseModelWithCovariates(BaseModel):
 
     def plot_prediction_actual_by_variable(
         self, data: Dict[str, Dict[str, torch.Tensor]], name: str = None, ax=None, log_scale: bool = None
-    ) -> Union[Dict[str, plt.Figure], plt.Figure]:
+    ):
         """
         Plot predicions and actual averages by variables
 
@@ -1860,6 +1868,10 @@ class BaseModelWithCovariates(BaseModel):
         Returns:
             Union[Dict[str, plt.Figure], plt.Figure]: matplotlib figure
         """
+        _check_matplotlib("plot_prediction_actual_by_variable")
+
+        from matplotlib import pyplot as plt
+
         if name is None:  # run recursion for figures
             figs = {name: self.plot_prediction_actual_by_variable(data, name) for name in data["support"].keys()}
             return figs
@@ -2230,7 +2242,7 @@ class AutoRegressiveBaseModel(BaseModel):
         ax=None,
         quantiles_kwargs: Dict[str, Any] = {},
         prediction_kwargs: Dict[str, Any] = {},
-    ) -> plt.Figure:
+    ):
         """
         Plot prediction of prediction vs actuals
 

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -1108,7 +1108,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                 ave_grads.append(p.grad.abs().cpu().mean())
                 self.logger.experiment.add_histogram(tag=name, values=p.grad, global_step=self.global_step)
 
-        mpl_available = _check_matplotlib("log_gradient_flow", raise_exception=False)
+        mpl_available = _check_matplotlib("log_gradient_flow", raise_error=False)
 
         if not mpl_available:
             return None

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -263,6 +263,11 @@ class NBeats(BaseModel):
         """
         Log interpretation of network predictions in tensorboard.
         """
+        mpl_available = _check_matplotlib("log_interpretation", raise_exception=False)
+
+        if not mpl_available:
+            return None
+
         label = ["val", "train"][self.training]
         if self.log_interval > 0 and batch_idx % self.log_interval == 0:
             fig = self.plot_interpretation(x, out, idx=0)

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -263,7 +263,7 @@ class NBeats(BaseModel):
         """
         Log interpretation of network predictions in tensorboard.
         """
-        mpl_available = _check_matplotlib("log_interpretation", raise_exception=False)
+        mpl_available = _check_matplotlib("log_interpretation", raise_error=False)
 
         if not mpl_available:
             return None

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -4,7 +4,6 @@ N-Beats model for timeseries forecasting without covariates.
 
 from typing import Dict, List
 
-import matplotlib.pyplot as plt
 import torch
 from torch import nn
 
@@ -13,6 +12,7 @@ from pytorch_forecasting.data.encoders import NaNLabelEncoder
 from pytorch_forecasting.metrics import MAE, MAPE, MASE, RMSE, SMAPE, MultiHorizonMetric
 from pytorch_forecasting.models.base_model import BaseModel
 from pytorch_forecasting.models.nbeats.sub_modules import NBEATSGenericBlock, NBEATSSeasonalBlock, NBEATSTrendBlock
+from pytorch_forecasting.utils._dependencies import _check_matplotlib
 
 
 class NBeats(BaseModel):
@@ -280,7 +280,7 @@ class NBeats(BaseModel):
         idx: int,
         ax=None,
         plot_seasonality_and_generic_on_secondary_axis: bool = False,
-    ) -> plt.Figure:
+    ):
         """
         Plot interpretation.
 
@@ -299,6 +299,10 @@ class NBeats(BaseModel):
         Returns:
             plt.Figure: matplotlib figure
         """
+        _check_matplotlib("plot_interpretation")
+
+        import matplotlib.pyplot as plt
+
         if ax is None:
             fig, ax = plt.subplots(2, 1, figsize=(6, 8))
         else:

--- a/pytorch_forecasting/models/nhits/__init__.py
+++ b/pytorch_forecasting/models/nhits/__init__.py
@@ -5,7 +5,6 @@ N-HiTS model for timeseries forecasting with covariates.
 from copy import copy
 from typing import Dict, List, Optional, Tuple, Union
 
-from matplotlib import pyplot as plt
 import numpy as np
 import torch
 from torch import nn
@@ -17,6 +16,7 @@ from pytorch_forecasting.models.base_model import BaseModelWithCovariates
 from pytorch_forecasting.models.nhits.sub_modules import NHiTS as NHiTSModule
 from pytorch_forecasting.models.nn.embeddings import MultiEmbedding
 from pytorch_forecasting.utils import create_mask, to_list
+from pytorch_forecasting.utils._dependencies import _check_matplotlib
 
 
 class NHiTS(BaseModelWithCovariates):
@@ -419,7 +419,7 @@ class NHiTS(BaseModelWithCovariates):
         output: Dict[str, torch.Tensor],
         idx: int,
         ax=None,
-    ) -> plt.Figure:
+    ):
         """
         Plot interpretation.
 
@@ -436,6 +436,10 @@ class NHiTS(BaseModelWithCovariates):
         Returns:
             plt.Figure: matplotlib figure
         """
+        _check_matplotlib("plot_interpretation")
+
+        from matplotlib import pyplot as plt
+
         if not isinstance(self.loss, MultiLoss):  # not multi-target
             prediction = self.to_prediction(dict(prediction=output["prediction"][[idx]].detach()))[0].cpu()
             block_forecasts = [

--- a/pytorch_forecasting/models/nhits/__init__.py
+++ b/pytorch_forecasting/models/nhits/__init__.py
@@ -539,7 +539,7 @@ class NHiTS(BaseModelWithCovariates):
         """
         Log interpretation of network predictions in tensorboard.
         """
-        mpl_available = _check_matplotlib("log_interpretation", raise_exception=False)
+        mpl_available = _check_matplotlib("log_interpretation", raise_error=False)
 
         if not mpl_available:
             return None

--- a/pytorch_forecasting/models/nhits/__init__.py
+++ b/pytorch_forecasting/models/nhits/__init__.py
@@ -539,6 +539,11 @@ class NHiTS(BaseModelWithCovariates):
         """
         Log interpretation of network predictions in tensorboard.
         """
+        mpl_available = _check_matplotlib("log_interpretation", raise_exception=False)
+
+        if not mpl_available:
+            return None
+
         label = ["val", "train"][self.training]
         if self.log_interval > 0 and batch_idx % self.log_interval == 0:
             fig = self.plot_interpretation(x, out, idx=0)

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -5,7 +5,6 @@ The temporal fusion transformer is a powerful predictive model for forecasting t
 from copy import copy
 from typing import Dict, List, Tuple, Union
 
-from matplotlib import pyplot as plt
 import numpy as np
 import torch
 from torch import nn
@@ -24,6 +23,7 @@ from pytorch_forecasting.models.temporal_fusion_transformer.sub_modules import (
     VariableSelectionNetwork,
 )
 from pytorch_forecasting.utils import create_mask, detach, integer_histogram, masked_op, padded_stack, to_list
+from pytorch_forecasting.utils._dependencies import _check_matplotlib
 
 
 class TemporalFusionTransformer(BaseModelWithCovariates):
@@ -690,7 +690,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         show_future_observed: bool = True,
         ax=None,
         **kwargs,
-    ) -> plt.Figure:
+    ):
         """
         Plot actuals vs prediction and attention
 
@@ -706,6 +706,9 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         Returns:
             plt.Figure: matplotlib figure
         """
+        _check_matplotlib("plot_prediction")
+
+        from matplotlib import pyplot as plt
 
         # plot prediction as normal
         fig = super().plot_prediction(

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -706,10 +706,6 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         Returns:
             plt.Figure: matplotlib figure
         """
-        _check_matplotlib("plot_prediction")
-
-        from matplotlib import pyplot as plt
-
         # plot prediction as normal
         fig = super().plot_prediction(
             x,
@@ -738,7 +734,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
                 f.tight_layout()
         return fig
 
-    def plot_interpretation(self, interpretation: Dict[str, torch.Tensor]) -> Dict[str, plt.Figure]:
+    def plot_interpretation(self, interpretation: Dict[str, torch.Tensor]):
         """
         Make figures that interpret model.
 
@@ -751,6 +747,10 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         Returns:
             dictionary of matplotlib figures
         """
+        _check_matplotlib("plot_interpretation")
+
+        import matplotlib.pyplot as plt
+
         figs = {}
 
         # attention
@@ -792,6 +792,10 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         """
         Log interpretation metrics to tensorboard.
         """
+        _check_matplotlib("log_interpretation")
+
+        import matplotlib.pyplot as plt
+
         # extract interpretations
         interpretation = {
             # use padded_stack because decoder length histogram can be of different length

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -792,10 +792,6 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         """
         Log interpretation metrics to tensorboard.
         """
-        _check_matplotlib("log_interpretation")
-
-        import matplotlib.pyplot as plt
-
         # extract interpretations
         interpretation = {
             # use padded_stack because decoder length histogram can be of different length
@@ -819,6 +815,13 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         )
         interpretation["attention"] = interpretation["attention"] / attention_occurances.pow(2).clamp(1.0)
         interpretation["attention"] = interpretation["attention"] / interpretation["attention"].sum()
+
+        mpl_available = _check_matplotlib("log_interpretation", raise_exception=False)
+
+        if not mpl_available:
+            return None
+
+        import matplotlib.pyplot as plt
 
         figs = self.plot_interpretation(interpretation)  # make interpretation figures
         label = self.current_stage

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -816,7 +816,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         interpretation["attention"] = interpretation["attention"] / attention_occurances.pow(2).clamp(1.0)
         interpretation["attention"] = interpretation["attention"] / interpretation["attention"].sum()
 
-        mpl_available = _check_matplotlib("log_interpretation", raise_exception=False)
+        mpl_available = _check_matplotlib("log_interpretation", raise_error=False)
 
         if not mpl_available:
             return None

--- a/pytorch_forecasting/utils/_dependencies.py
+++ b/pytorch_forecasting/utils/_dependencies.py
@@ -40,17 +40,23 @@ def _get_installed_packages():
     return _get_installed_packages_private().copy()
 
 
-def _check_matplotlib(ref="This feature"):
+def _check_matplotlib(ref="This feature", raise_error=True):
     """Check if matplotlib is installed.
+
+    Parameters
+    ----------
+    ref : str, optional (default="This feature")
+        reference to the feature that requires matplotlib, used in error message
+    raise_error : bool, optional (default=True)
+        whether to raise an error if matplotlib is not installed
 
     Returns
     -------
     bool : whether matplotlib is installed
-    """  
+    """
     pkgs = _get_installed_packages()
 
-    if "matplotlib" not in pkgs:
-        raise ImportError(
-            f"{ref} requires matplotlib. "
-            "Please install matplotlib with `pip install matplotlib`."
-        )
+    if raise_error and "matplotlib" not in pkgs:
+        raise ImportError(f"{ref} requires matplotlib. Please install matplotlib with `pip install matplotlib`.")
+
+    return "matplotlib" in pkgs

--- a/pytorch_forecasting/utils/_dependencies.py
+++ b/pytorch_forecasting/utils/_dependencies.py
@@ -38,3 +38,19 @@ def _get_installed_packages():
         MAJOR.MINOR.PATCH version format is used for versions, e.g., "1.2.3"
     """
     return _get_installed_packages_private().copy()
+
+
+def _check_matplotlib(ref="This feature"):
+    """Check if matplotlib is installed.
+
+    Returns
+    -------
+    bool : whether matplotlib is installed
+    """  
+    pkgs = _get_installed_packages()
+
+    if "matplotlib" not in pkgs:
+        raise ImportError(
+            f"{ref} requires matplotlib. "
+            "Please install matplotlib with `pip install matplotlib`."
+        )

--- a/tests/test_models/test_nbeats.py
+++ b/tests/test_models/test_nbeats.py
@@ -7,6 +7,7 @@ from lightning.pytorch.loggers import TensorBoardLogger
 import pytest
 
 from pytorch_forecasting.models import NBeats
+from pytorch_forecasting.utils._dependencies import _get_installed_packages
 
 
 def test_integration(dataloaders_fixed_window_without_covariates, tmp_path):
@@ -76,6 +77,10 @@ def test_pickle(model):
     pickle.loads(pkl)
 
 
+@pytest.mark.skipif(
+    "matplotlib" not in _get_installed_packages(),
+    reason="skip test if required package matplotlib not installed",
+)
 def test_interpretation(model, dataloaders_fixed_window_without_covariates):
     raw_predictions = model.predict(
         dataloaders_fixed_window_without_covariates["val"], mode="raw", return_x=True, fast_dev_run=True

--- a/tests/test_models/test_nhits.py
+++ b/tests/test_models/test_nhits.py
@@ -12,6 +12,7 @@ from pytorch_forecasting.data.timeseries import TimeSeriesDataSet
 from pytorch_forecasting.metrics import MQF2DistributionLoss, QuantileLoss
 from pytorch_forecasting.metrics.distributions import ImplicitQuantileNetworkDistributionLoss
 from pytorch_forecasting.models import NHiTS
+from pytorch_forecasting.utils._dependencies import _get_installed_packages
 
 
 def _integration(dataloader, tmp_path, trainer_kwargs=None, **kwargs):
@@ -147,6 +148,10 @@ def test_pickle(model):
     pickle.loads(pkl)
 
 
+@pytest.mark.skipif(
+    "matplotlib" not in _get_installed_packages(),
+    reason="skip test if required package matplotlib not installed",
+)
 def test_interpretation(model, dataloaders_with_covariates):
     raw_predictions = model.predict(dataloaders_with_covariates["val"], mode="raw", return_x=True, fast_dev_run=True)
     model.plot_prediction(raw_predictions.x, raw_predictions.output, idx=0, add_loss_to_title=True)

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -23,6 +23,7 @@ from pytorch_forecasting.metrics import (
 )
 from pytorch_forecasting.models import TemporalFusionTransformer
 from pytorch_forecasting.models.temporal_fusion_transformer.tuning import optimize_hyperparameters
+from pytorch_forecasting.utils._dependencies import _get_installed_packages
 
 if sys.version.startswith("3.6"):  # python 3.6 does not have nullcontext
     from contextlib import contextmanager
@@ -293,6 +294,10 @@ def test_predict_dependency(model, dataloaders_with_covariates, data_with_covari
     model.predict_dependency(dataset, variable="agency", values=data_with_covariates.agency.unique()[:2], **kwargs)
 
 
+@pytest.mark.skipif(
+    "matplotlib" not in _get_installed_packages(),
+    reason="skip test if required package matplotlib not installed",
+)
 def test_actual_vs_predicted_plot(model, dataloaders_with_covariates):
     prediction = model.predict(dataloaders_with_covariates["val"], return_x=True)
     averages = model.calculate_prediction_actual_by_variable(prediction.x, prediction.output)


### PR DESCRIPTION
Isolates `matplotlib` as soft dependency in a new soft dep set `all_extras`. https://github.com/jdb78/pytorch-forecasting/issues/1616

The imports happen in `plot_sth` methods throughout the code base, some attached to classes, some not.
This allows to use `pytorch-forecasting` without plotting or graphical logging, or use a different plotting backend manually.

Isolation strategy:

* where the purpose of the function is creating a plot or nothing else, absence of `matplotlib` raises an exception
* where `matplotlib` is additional or part of the logic, absence of `matplotlib` causes the specific parts to be skipped. Example: `log_gradient_flow` - this is crucial, as raising an exception would prevent the models from running.