### PR TITLE
[MNT] isolate `cpflows` to its soft dependency set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ dev = [
   "pytest-dotenv>=0.5.2,<1.0.0",
   "tensorboard>=2.12.1,<3.0.0",
   "pandoc>=2.3,<3.0.0",
-  "cpflows",
 ]
 
 github-actions = ["pytest-github-actions-annotate-failures"]


### PR DESCRIPTION
This Pr isolates `cpflows` to its soft dependency set again - I think it was already a soft dependency before we started to rework `pyproject`, somehow it ended up in `dev`?

This PR restores its original status as a soft dependency, as part of `mqf2`.