### PR TITLE
[MNT] CI runs without soft dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
 
   pytest-nosoftdeps:
-    name: no-softdeps
+    name: Run pytest without soft dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
 
   pytest-nosoftdeps:
-    name: no-softdeps
+    name: no softdeps
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
 
   pytest-nosoftdeps:
-    name: no softdeps
+    name: no-softdeps
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,45 @@ jobs:
         run: build_tools/run_examples.sh
         shell: bash
 
+  pytest-nosoftdeps:
+    name: Run pytest without soft dependencies
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install libomp  # https://github.com/pytorch/pytorch/issues/20030
+
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash
+        run: echo version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))") >> $GITHUB_OUTPUT
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          pip install ".[dev,github-actions]"
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Run pytest
+        shell: bash
+        run: python -m pytest tests
+
   pytest:
     name: Run pytest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
 
   pytest-nosoftdeps:
-    name: Run pytest without soft dependencies
+    name: no-softdeps
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/tests/test_models/test_nhits.py
+++ b/tests/test_models/test_nhits.py
@@ -12,6 +12,7 @@ from pytorch_forecasting.data.timeseries import TimeSeriesDataSet
 from pytorch_forecasting.metrics import MQF2DistributionLoss, QuantileLoss
 from pytorch_forecasting.metrics.distributions import ImplicitQuantileNetworkDistributionLoss
 from pytorch_forecasting.models import NHiTS
+from pytorch_forecasting.utils._dependencies import _get_installed_packages
 
 
 def _integration(dataloader, tmp_path, trainer_kwargs=None, **kwargs):
@@ -81,18 +82,20 @@ def _integration(dataloader, tmp_path, trainer_kwargs=None, **kwargs):
     )
 
 
-@pytest.mark.parametrize(
-    "dataloader",
-    [
-        "with_covariates",
-        "different_encoder_decoder_size",
-        "fixed_window_without_covariates",
-        "multi_target",
-        "quantiles",
-        "multivariate-quantiles",
-        "implicit-quantiles",
-    ],
-)
+LOADERS = [
+    "with_covariates",
+    "different_encoder_decoder_size",
+    "fixed_window_without_covariates",
+    "multi_target",
+    "quantiles",
+    "implicit-quantiles",
+]
+
+if "cpflows" in _get_installed_packages():
+    LOADERS += ["multivariate-quantiles"]
+
+
+@pytest.mark.parametrize("dataloader", LOADERS)
 def test_integration(
     dataloaders_with_covariates,
     dataloaders_with_different_encoder_decoder_length,

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -23,6 +23,8 @@ from pytorch_forecasting.metrics import (
 )
 from pytorch_forecasting.models import TemporalFusionTransformer
 from pytorch_forecasting.models.temporal_fusion_transformer.tuning import optimize_hyperparameters
+from pytorch_forecasting.utils._dependencies import _get_installed_packages
+
 
 if sys.version.startswith("3.6"):  # python 3.6 does not have nullcontext
     from contextlib import contextmanager
@@ -69,6 +71,10 @@ def test_distribution_loss(data_with_covariates, tmp_path):
     )
 
 
+@pytest.mark.skipif(
+    "cpflows" not in _get_installed_packages(),
+    reason="Test skipped if required package cpflows not available",
+)
 def test_mqf2_loss(data_with_covariates, tmp_path):
     data_with_covariates = data_with_covariates.assign(volume=lambda x: x.volume.round())
     dataloaders_with_covariates = make_dataloaders(

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -25,7 +25,6 @@ from pytorch_forecasting.models import TemporalFusionTransformer
 from pytorch_forecasting.models.temporal_fusion_transformer.tuning import optimize_hyperparameters
 from pytorch_forecasting.utils._dependencies import _get_installed_packages
 
-
 if sys.version.startswith("3.6"):  # python 3.6 does not have nullcontext
     from contextlib import contextmanager
 


### PR DESCRIPTION
This adds test runs without soft dependencies.

The run covers currently removal of the two extant soft dependency sets, `graph` and `mqf2`. This tests isolation in the extents of test coverage, and also isolation of the tests themselves requiring these.

The setup can be extended in the future to further soft dependency sets, testing that the code functions in their absence.