### PR TITLE
[MNT] make `codecov` patch coverage informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,6 @@ coverage:
     project:
       default:
         threshold: 0.2%
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
The `codecov` patch job, i.e., "how many lines of the diff are covered", can cause CI failures currently - these are misleading in particular if the code is maintenance or config code and itself not covered due to reasonable circumstances.

To avoid random failures in such cases, the patch coverage is turned to be informational. The total coverage condition, i.e., that total rpeository coverage should not drop too much through a PR, is not changed.