### PR TITLE
[MNT] isolate `pytorch-optimizer` as soft dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev,github-actions,graph,mqf2]"
+          python -m pip install ".[dev,all_extras,github-actions,graph,mqf2]"
 
       - name: Show dependencies
         run:  python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          pip install ".[dev,github-actions,graph,mqf2]"
+          pip install ".[dev,all_extras,github-actions,graph,mqf2]"
 
       - name: Show dependencies
         run: python -m pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,13 @@ dependencies = [
   "scikit-learn >=1.2,<2.0",
   "matplotlib",
   "statsmodels",
-  "pytorch-optimizer >=2.5.1,<3.0.0",
 ]
 
 [project.optional-dependencies]
+
+all_extras = [
+  "pytorch-optimizer >=2.5.1,<3.0.0",
+]
 
 dev = [
   "pydocstyle >=6.1.1,<7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
 [project.optional-dependencies]
 
 all_extras = [
-  "pytorch-optimizer >=2.5.1,<3.0.0",
+  "pytorch_optimizer >=2.5.1,<3.0.0",
 ]
 
 dev = [

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -461,7 +461,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     "In pytorch-forecasting models, from version 1.2.0, "
                     "the default optimizer will be 'adam', in order to "
                     "minimize the number of dependencies in default parameter settings. " 
-                    "Users who wish to continue using 'ranger' as default optimizer "
+                    "Users who wish to ensure their code continues using 'ranger' as optimizer "
                     "should ensure that pytorch_optimizer is installed, and set the optimizer "
                     "parameter explicitly to 'ranger'.",
                     stacklevel=2,
@@ -476,7 +476,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     "From version 1.2.0, the default optimizer will be 'adam' "
                     "regardless of whether pytorch_optimizer is installed, in order to "
                     "minimize the number of dependencies in default parameter settings. " 
-                    "Users who wish to continue using 'ranger' as default optimizer "
+                    "Users who wish to ensure their code continues using 'ranger' as optimizer "
                     "should ensure that pytorch_optimizer is installed, and set the optimizer "
                     "parameter explicitly to 'ranger'.",
                     stacklevel=2,

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -452,12 +452,35 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         frame = inspect.currentframe()
         init_args = get_init_args(frame)
 
+        # TODO 1.2.0: remove warnings and change default optimizer to "adam"
         if init_args["optimizer"] is None:
             ptopt_in_env = "pytorch_optimizer" in _get_installed_packages()
             if ptopt_in_env:
                 init_args["optimizer"] = "ranger"
+                warnings.warn(
+                    "In pytorch-forecasting models, from version 1.2.0, "
+                    "the default optimizer will be 'adam', in order to "
+                    "minimize the number of dependencies in default parameter settings. " 
+                    "Users who wish to continue using 'ranger' as default optimizer "
+                    "should ensure that pytorch_optimizer is installed, and set the optimizer "
+                    "parameter explicitly to 'ranger'.",
+                    stacklevel=2,
+                )
             else:
                 init_args["optimizer"] = "adam"
+                warnings.warn(
+                    "In pytorch-forecasting models, since version 1.1.0, "
+                    "the default optimizer defaults to 'adam', "
+                    "if pytorch_optimizer is not installed, "
+                    "otherwise it defaults to 'ranger' from pytorch_optimizer. "
+                    "From version 1.2.0, the default optimizer will be 'adam' "
+                    "regardless of whether pytorch_optimizer is installed, in order to "
+                    "minimize the number of dependencies in default parameter settings. " 
+                    "Users who wish to continue using 'ranger' as default optimizer "
+                    "should ensure that pytorch_optimizer is installed, and set the optimizer "
+                    "parameter explicitly to 'ranger'.",
+                    stacklevel=2,
+                )
 
         self.save_hyperparameters(
             {name: val for name, val in init_args.items() if name not in self.hparams and name not in ["self"]}

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -460,7 +460,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                 warnings.warn(
                     "In pytorch-forecasting models, from version 1.2.0, "
                     "the default optimizer will be 'adam', in order to "
-                    "minimize the number of dependencies in default parameter settings. " 
+                    "minimize the number of dependencies in default parameter settings. "
                     "Users who wish to ensure their code continues using 'ranger' as optimizer "
                     "should ensure that pytorch_optimizer is installed, and set the optimizer "
                     "parameter explicitly to 'ranger'.",
@@ -475,7 +475,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     "otherwise it defaults to 'ranger' from pytorch_optimizer. "
                     "From version 1.2.0, the default optimizer will be 'adam' "
                     "regardless of whether pytorch_optimizer is installed, in order to "
-                    "minimize the number of dependencies in default parameter settings. " 
+                    "minimize the number of dependencies in default parameter settings. "
                     "Users who wish to ensure their code continues using 'ranger' as optimizer "
                     "should ensure that pytorch_optimizer is installed, and set the optimizer "
                     "parameter explicitly to 'ranger'.",

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -1131,7 +1131,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         Returns:
             Tuple[List]: first entry is list of optimizers and second is list of schedulers
         """
-        ptopt_in_env = "pytorch-optimizer" in _get_installed_packages
+        ptopt_in_env = "pytorch-optimizer" in _get_installed_packages()
         # either set a schedule of lrs or find it dynamically
         if self.hparams.optimizer_params is None:
             optimizer_params = {}

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -410,7 +410,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         optimizer_params: Dict[str, Any] = None,
         monotone_constaints: Dict[str, int] = {},
         output_transformer: Callable = None,
-        optimizer="Ranger",
+        optimizer=None,
     ):
         """
         BaseModel for timeseries forecasting from which to inherit from
@@ -444,12 +444,21 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                 or ``pytorch_optimizer``.
                 Alternatively, a class or function can be passed which takes parameters as first argument and
                 a `lr` argument (optionally also `weight_decay`). Defaults to
-                `"ranger" <https://pytorch-optimizers.readthedocs.io/en/latest/optimizer_api.html#ranger21>`_.
+                `"ranger" <https://pytorch-optimizers.readthedocs.io/en/latest/optimizer_api.html#ranger21>`_,
+                if pytorch_optimizer is installed, otherwise "adam".
         """
         super().__init__()
         # update hparams
         frame = inspect.currentframe()
         init_args = get_init_args(frame)
+
+        if init_args["optimizer"] is None:
+            ptopt_in_env = "pytorch_optimizer" in _get_installed_packages()
+            if ptopt_in_env:
+                init_args["optimizer"] = "ranger"
+            else:
+                init_args["optimizer"] = "adam"
+
         self.save_hyperparameters(
             {name: val for name, val in init_args.items() if name not in self.hparams and name not in ["self"]}
         )

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -1131,7 +1131,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         Returns:
             Tuple[List]: first entry is list of optimizers and second is list of schedulers
         """
-        ptopt_in_env = "pytorch-optimizer" in _get_installed_packages()
+        ptopt_in_env = "pytorch_optimizer" in _get_installed_packages()
         # either set a schedule of lrs or find it dynamically
         if self.hparams.optimizer_params is None:
             optimizer_params = {}
@@ -1161,8 +1161,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         elif self.hparams.optimizer == "ranger":
             if not ptopt_in_env:
                 raise ImportError(
-                    "optimizer 'ranger' requires pytorch-optimizer in the evironment. "
-                    "Please install pytorch-optimizer with `pip install pytorch-optimizer`."
+                    "optimizer 'ranger' requires pytorch_optimizer in the evironment. "
+                    "Please install pytorch_optimizer with `pip install pytorch_optimizer`."
                 )
             from pytorch_optimizer import Ranger21
 

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -1204,6 +1204,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     optimizer = getattr(pytorch_optimizer, self.hparams.optimizer)(
                         self.parameters(), lr=lr, **optimizer_params
                     )
+            else:
+                raise ValueError(f"Optimizer of self.hparams.optimizer={self.hparams.optimizer} unknown")
         else:
             raise ValueError(f"Optimizer of self.hparams.optimizer={self.hparams.optimizer} unknown")
 

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -469,7 +469,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
             else:
                 init_args["optimizer"] = "adam"
                 warnings.warn(
-                    "In pytorch-forecasting models, since version 1.1.0, "
+                    "In pytorch-forecasting models, on versions 1.1.X, "
                     "the default optimizer defaults to 'adam', "
                     "if pytorch_optimizer is not installed, "
                     "otherwise it defaults to 'ranger' from pytorch_optimizer. "


### PR DESCRIPTION
Isolates `pytorch-optimizer` as soft dependency in a new soft dep set `all_extras`. https://github.com/jdb78/pytorch-forecasting/issues/1616

The imports happen only in `BaseModel`, when resolving aliases for `optimizer`.

Isolation consists of two steps:
* replacing resolution of the alias with a request to install the package, and removing from resolution scope if not installed
* replacing the default optimizer `"ranger"` with `"adam"` if `pytorch-optimizer` is not installed (left at `"ranger"` if installed)

Deprecation messages and actions are added, to changne the default to `"adam"` from 1.2.0, in order to minimize the number of dependencies in default parameter settings

