### PR TITLE
[MNT] rename `pytorch-optimizer` dep to `pytorch_optimizer` and raise upper bound to `<4`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
   "scikit-learn >=1.2,<2.0",
   "matplotlib",
   "statsmodels",
-  "pytorch-optimizer >=2.5.1,<3.0.0",
+  "pytorch_optimizer >=2.5.1,<4.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This renames the `pytorch-optimizer` dep to `pytorch_optimizer` and raise upper bound to `<4`

The package seems to have been renamed to `pytorch_optimizer` on pypi?