### PR TITLE
[MNT] clean up and comment dep sets in `pyproject.toml`, remove unused `graph` dep set from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev,github-actions,graph,mqf2]"
+          python -m pip install ".[dev,github-actions,mqf2]"
 
       - name: Show dependencies
         run:  python -m pip list
@@ -103,7 +103,11 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
+<<<<<<< Updated upstream
           pip install ".[dev,github-actions,graph,mqf2]"
+=======
+          pip install ".[dev,all_extras,github-actions,mqf2]"
+>>>>>>> Stashed changes
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,11 +103,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-<<<<<<< Updated upstream
-          pip install ".[dev,github-actions,graph,mqf2]"
-=======
           pip install ".[dev,all_extras,github-actions,mqf2]"
->>>>>>> Stashed changes
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          pip install ".[dev,all_extras,github-actions,mqf2]"
+          pip install ".[dev,all_extras,github-actions]"
 
       - name: Show dependencies
         run: python -m pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,42 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# there are the following dependency sets:
+# - all_extras - all soft dependencies
+# - granular dependency sets:
+#     - tuning - dependencies for tuning hyperparameters via optuna
+#     - mqf2 - dependencies for multivariate quantile loss
+#     - graph - dependencies for graph based forecasting
+# - dev - the developer dependency set, for contributors to pytorch-forecasting
+# - CI related: e.g., dev, github-actions. Not for users of sktime.
+#
+# soft dependencies are not required for the core functionality of sktime
+# but are required by popular estimators, e.g., prophet, tbats, etc.
 
+# all soft dependencies
+#
+# users can install via "pip install pytorch-forecasting[all_extras]"
+#
+all_extras = [
+  "cpflows",
+  "optuna >=3.1.0,<4.0.0",
+  "optuna-integration",
+  "statsmodels",
+]
+
+tuning = [
+  "optuna >=3.1.0,<4.0.0",
+  "optuna-integration",
+  "statsmodels",
+]
+
+mqf2 = ["cpflows"]
+
+# the graph set is not currently used within pytorch-forecasting
+# but is kept for future development, as it has already been released
+graph = ["networkx"]
+
+# dev - the developer dependency set, for contributors to pytorch-forecasting
 dev = [
   "pydocstyle >=6.1.1,<7.0.0",
   # checks and make tools
@@ -101,8 +136,6 @@ dev = [
 ]
 
 github-actions = ["pytest-github-actions-annotate-failures"]
-graph = ["networkx"]
-mqf2 = ["cpflows"]
 
 [tool.setuptools.packages.find]
 exclude = ["build_tools"]


### PR DESCRIPTION
Cleans up dependency management without making changes to existing dep sets.

* create new dep set `all_extras` containing all used soft dependencies
* reorder dep sets in `pyproject.toml` and and comments about their usage
* remove unused `graph` dep set from installations in CI - the contained `networkx` package is never imported within the code base