### PR TITLE
[MNT] pypi release only on GH release

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,15 +1,8 @@
 name: PyPI Release
 
-# https://help.github.com/en/actions/reference/events-that-trigger-workflows
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the master branch
-  push:
-    branches:
-      - master
   release:
-    types:
-      - created
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
This PR ensures that the release workflow is triggered only on GitHub release.

Currently, it seems the release is triggered on every push to `master` - though it has thankfully failed for the past merges.