### PR TITLE
[MNT] improved release workflow

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -12,29 +12,81 @@ on:
       - created
 
 jobs:
-  build:
+  build_wheels:
+    name: Build wheels
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.11
+      - uses: actions/checkout@v4
 
-      - name: Install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build wheel
+        run: |
+          python -m pip install build
+          python -m build --wheel --sdist --outdir wheelhouse
+
+      - name: Store wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse/*
+
+  pytest-nosoftdeps:
+    name: no-softdeps
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install libomp  # https://github.com/pytorch/pytorch/issues/20030
+
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash
+        run: echo version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))") >> $GITHUB_OUTPUT
+
+      - name: Install dependencies
         shell: bash
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          python -m pip install poetry-dynamic-versioning[plugin]
+          pip install ".[dev,github-actions]"
 
-      - name: Set poetry path variable
-        run: echo "/Users/runner/.local/bin" >> $GITHUB_PATH
+      - name: Show dependencies
+        run: python -m pip list
 
-      - name: Build
-        run: |
-          poetry build
+      - name: Run pytest
+        shell: bash
+        run: python -m pytest tests
 
-      - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
-        run: |
-          poetry publish --username "${{ secrets.PYPI_USER }}" --password "${{ secrets.PYPI_PASSWORD }}"
+  upload_wheels:
+    name: Upload wheels to PyPI
+    runs-on: ubuntu-latest
+    needs: [pytest-nosoftdeps]
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USER }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+          packages-dir: wheelhouse/


### PR DESCRIPTION
Makes changes and improvements to the release workflow:

* using python 3.11
* based on `pip` and not `poetry`
* gating the actual push to `pypi` behind a full run of the nosoftdeps tests to avoid pushing a failing version