### PR TITLE
[ENH] Enable `DeprecationWarning` , `PendingDeprecationWarning` and `FutureWarning` when running pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,5 +220,8 @@ filterwarnings = [
     "ignore:The number of training samples \\(\\d+\\) is smaller than the logging interval Trainer\\(:UserWarning",
     "ignore:The dataloader, [\\_\\s]+ \\d+, does not have many workers which may be a bottleneck.:UserWarning",
     "ignore:Consider increasing the value of the `num_workers` argument`:UserWarning",
+    "default::DeprecationWarning",
+    "default::PendingDeprecationWarning",
+    "default::FutureWarning",
     "ignore::UserWarning"
 ]


### PR DESCRIPTION
This PR enables seeing debuggable `DeprecationWarning` when running the tests with pytest, no need to specify a flag for warnings.

Related to https://github.com/sktime/pytorch-forecasting/issues/1764