### PR TITLE
[MNT] Add version bound for `lightning`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "Forecasting timeseries with PyTorch - dataloaders, normalizers, m
 dependencies = [
   "numpy<=3.0.0",
   "torch >=2.0.0,!=2.0.1,<3.0.0",
-  "lightning >=2.0.0,<3.0.0",
+  "lightning >=2.0.0,<2.6.0",
   "scipy >=1.8,<2.0",
   "pandas >=1.3.0,<3.0.0",
   "scikit-learn >=1.2,<2.0",


### PR DESCRIPTION
Add version bound for `lightning` to be `"lightning <2.6.0"` to isolate the problematic version and look for issues in the latest version
See #1998 