### PR TITLE
[MNT] Add CI step with pinned dependencies as of Nov 2025

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,13 +115,12 @@ jobs:
         run: python -m pytest
 
   test-deps-2025:
-    name: no-softdeps
-    needs: code-quality
+    needs: pytest-nosoftdeps
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: ubuntu-latest
         python-version: 3.12
 
     steps:
@@ -131,11 +130,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Setup macOS
-        if: runner.os == 'macOS'
-        run: |
-          brew install libomp  # https://github.com/pytorch/pytorch/issues/20030
 
       - name: Get full Python version
         id: full-python-version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,8 +120,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ubuntu-latest
-        python-version: 3.12
+        os: ["ubuntu-latest"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,46 @@ jobs:
         shell: bash
         run: python -m pytest
 
+  test-deps-2025:
+    name: no-softdeps
+    needs: code-quality
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: "3.12"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install libomp  # https://github.com/pytorch/pytorch/issues/20030
+
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash
+        run: echo version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))") >> $GITHUB_OUTPUT
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          pip install ".[dev, dependencies_2025, github-actions]"
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Run pytest
+        shell: bash
+        run: python -m pytest
+
   pytest:
     name: Run pytest
     needs: pytest-nosoftdeps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: "3.12"
+        python-version: 3.12
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,17 @@ docs = [
   "docutils",
 ]
 
+# Core Dep set just before the lightning 2.6 release
+dependencies_2025 = [
+  "numpy==2.2.6",
+  "torch ==2.9.1",
+  "lightning ==2.5.6",
+  "scipy ==1.15.3",
+  "pandas ==2.3.3",
+  "scikit-learn ==1.7.2",
+  "scikit-base ==0.13.0",
+]
+
 github-actions = ["pytest-github-actions-annotate-failures"]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This PR  adds CI step with pinned dependencies as of Nov 2025 just before the `lightning 2.6` release.