### PR TITLE
[MNT] Bump pandas version to `pandas 3.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "torch >=2.0.0,!=2.0.1,<3.0.0",
   "lightning >=2.0.0,<2.7.0",
   "scipy >=1.8,<2.0",
-  "pandas >=1.3.0,<3.0.0",
+  "pandas >=1.3.0,<3.1.0",
   "scikit-learn >=1.2,<2.0",
   "scikit-base <0.14.0",
 ]


### PR DESCRIPTION
Bumps `pandas` bound to allow `pandas 3.0`.

Draft to see failures and passes.