### PR TITLE
fix: add map_location parameter to TimeSeriesDataSet.load()

### DIFF
--- a/pytorch_forecasting/data/timeseries/_timeseries.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries.py
@@ -1047,17 +1047,24 @@ class TimeSeriesDataSet(Dataset):
         torch.save(self, fname)
 
     @classmethod
-    def load(cls: type[TimeSeriesDataType], fname: str) -> TimeSeriesDataType:
+    def load(
+        cls: type[TimeSeriesDataType],
+        fname: str,
+        map_location: Optional[torch.device] = None,
+    ) -> TimeSeriesDataType:
         """
         Load dataset from disk
 
         Args:
             fname (str): filename to load from
+            map_location (torch.device, optional): device to load tensors to.
+                Defaults to None (load on original device).
+                Use torch.device('cpu') to force CPU loading.
 
         Returns:
             TimeSeriesDataSet
         """
-        obj = torch.load(fname)
+        obj = torch.load(fname, map_location=map_location)
         assert isinstance(obj, cls), f"Loaded file is not of class {cls}"
         return obj
 


### PR DESCRIPTION
## Description
Add map_location parameter to the TimeSeriesDataSet.load() method to enable safe loading of datasets across different devices.

### Problem
The TimeSeriesDataSet.load() method used torch.load() without a map_location parameter, causing issues when:
- Loading tensors saved on GPU to CPU
- Sharing datasets across machines with varying hardware
- Training on GPU but deploying on CPU

This is a common issue for users who train on GPU but deploy on CPU, or share datasets across different machines.

### Solution
Added optional map_location parameter (defaults to None for backward compatibility) that:
- Follows PyTorch best practices for torch.load()
- Is consistent with BaseModel.load_from_checkpoint() pattern used elsewhere in the codebase
- Allows users to specify target device when loading datasets

### Usage Example
```python
# Load on CPU (even if saved on GPU)
dataset = TimeSeriesDataSet.load('dataset.pkl', map_location=torch.device('cpu'))

# Load on specific device
dataset = TimeSeriesDataSet.load('dataset.pkl', map_location=torch.device('cuda:0'))

# Load on original device (backward compatible)
dataset = TimeSeriesDataSet.load('dataset.pkl')
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
Fixes: #2069