### PR TITLE
[DOC] migration of docstrings to numpydoc style in embeddings layer

### DIFF
--- a/pytorch_forecasting/layers/_embeddings/_data_embedding.py
+++ b/pytorch_forecasting/layers/_embeddings/_data_embedding.py
@@ -14,12 +14,19 @@ import torch.nn.functional as F
 class DataEmbedding_inverted(nn.Module):
     """
     Data embedding module for time series data.
-    Args:
-        c_in (int): Number of input features.
-        d_model (int): Dimension of the model.
-        embed_type (str): Type of embedding to use. Defaults to "fixed".
-        freq (str): Frequency of the time series data. Defaults to "h".
-        dropout (float): Dropout rate. Defaults to 0.1.
+
+    Parameters
+    ----------
+    c_in : int
+         Number of input features.
+    d_model : int
+        Dimension of the model.
+    embed_type : str
+        Type of embedding to use. Defaults to "fixed".
+    freq : str
+        Frequency of the time series data. Defaults to "h".
+    dropout : float
+        Dropout rate. Defaults to 0.1.
     """
 
     def __init__(self, c_in, d_model, dropout=0.1):

--- a/pytorch_forecasting/layers/_embeddings/_en_embedding.py
+++ b/pytorch_forecasting/layers/_embeddings/_en_embedding.py
@@ -19,11 +19,17 @@ class EnEmbedding(nn.Module):
     """
     Encoder embedding module for time series data. Handles endogenous feature
     embeddings in this case.
-    Args:
-        n_vars (int): Number of input features.
-        d_model (int): Dimension of the model.
-        patch_len (int): Length of the patches.
-        dropout (float): Dropout rate. Defaults to 0.1.
+
+    Parameters
+    ----------
+    n_vars : int
+        Number of input features.
+    d_model : int
+        Dimension of the model.
+    patch_len : int
+        Length of the patches.
+    dropout : float
+        Dropout rate. Defaults to 0.1.
     """
 
     def __init__(self, n_vars, d_model, patch_len, dropout):

--- a/pytorch_forecasting/layers/_embeddings/_positional_embedding.py
+++ b/pytorch_forecasting/layers/_embeddings/_positional_embedding.py
@@ -14,9 +14,14 @@ import torch.nn.functional as F
 class PositionalEmbedding(nn.Module):
     """
     Positional embedding module for time series data.
-    Args:
-        d_model (int): Dimension of the model.
-        max_len (int): Maximum length of the input sequence. Defaults to 5000."""
+
+    Parameters
+    ----------
+    d_model : int
+        Dimension of the model.
+    max_len : int
+        Maximum length of the input sequence. Defaults to 5000.
+    """
 
     def __init__(self, d_model, max_len=5000):
         super().__init__()

--- a/pytorch_forecasting/layers/_embeddings/_sub_nn.py
+++ b/pytorch_forecasting/layers/_embeddings/_sub_nn.py
@@ -13,9 +13,9 @@ class embedding_cat_variables(nn.Module):
         ----------
         seq_len: int
             length of the sequence (sum of past and future steps)
-        lag: (int):
+        lag: int
             number of future step to be predicted
-        hidden_size: int
+        d_model: int
             dimension of all variables after they are embedded
         emb_dims: list
             size of the dictionary for embedding. One dimension for each categorical variable


### PR DESCRIPTION
Fixes #2066 

Moved the docstrings in the embeddings layer from the older google style to numpydoc style .
