### PR TITLE
Fix GPU memory growth in PredictCallback when return_y=True

### DIFF
--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -318,10 +318,10 @@ class PredictCallback(BasePredictionWriter):
             self._index.append(trainer.predict_dataloaders.dataset.x_to_index(x))
             out["index"] = self._index[-1]
         if self.return_decoder_lengths:
-            self._decode_lengths.append(lengths)
+            self._decode_lengths.append(lengths.cpu())
             out["decoder_lengths"] = self._decode_lengths[-1]
         if self.return_y:
-            self._y.append(batch[1])
+            self._y.append(move_to_device(detach(batch[1]), "cpu"))
             out["y"] = self._y[-1]
 
         if isinstance(out, dict):


### PR DESCRIPTION
## Summary

This PR fixes a GPU memory accumulation issue in  
`pytorch_forecasting/models/base/_base_model.py`, specifically inside the `PredictCallback.on_predict_batch_end` method.

`PredictCallback` collects batch outputs during `trainer.predict()`. While model outputs (`out`) and inputs (`x`) were correctly detached and moved to CPU after each batch, the target tensors (`batch[1]`) and `decoder_lengths` were still being stored on the GPU.

Because these tensors were appended to internal lists (`self._y` and `self._decode_lengths`) and only cleared at the end of the prediction epoch, GPU memory usage increased linearly with each batch when `return_y=True`.

The relevant pattern before this fix:

```python
# Correct handling
out = move_to_device(detach(out), "cpu")
x   = move_to_device(detach(x), "cpu")

# Problematic handling
if self.return_decoder_lengths:
    self._decode_lengths.append(lengths)  # still on GPU

if self.return_y:
    self._y.append(batch[1])              # raw CUDA tensors
````

This meant that during large inference runs, VRAM usage continuously increased until CUDA ran out of memory.

---

## Fix

This change applies the same CPU offloading pattern already used for `out` and `x` to both:

* `decoder_lengths`
* `batch[1]` (targets)

Updated logic:

```python
if self.return_decoder_lengths:
    self._decode_lengths.append(lengths.cpu())

if self.return_y:
    self._y.append(move_to_device(detach(batch[1]), "cpu"))
```

### Why this works

* `detach(...)` prevents any accidental graph retention.
* `move_to_device(..., "cpu")` immediately releases GPU memory for that batch.
* Returned behavior remains unchanged.
* All collected tensors are now consistently CPU-resident.

GPU memory usage now stays bounded regardless of dataset size.

---

## Verification

To reproduce the issue before this fix:

1. Train or load a model on GPU.
2. Run:

   ```python
   model.predict(dataloader, return_y=True, trainer_kwargs={"accelerator": "gpu"})
   ```
3. Monitor:

   * `torch.cuda.memory_allocated()`
   * `nvidia-smi`

### Before the fix

* GPU memory increases steadily per batch.
* VRAM usage grows linearly with dataset size.
* Large inference runs crash with `CUDA out of memory`.
* The same run succeeds when `return_y=False`.

### After the fix

* GPU memory remains stable during prediction.
* Only the current batch resides on the GPU.
* No progressive VRAM growth.
* Large-dataset inference completes successfully.

---

## Impact

* Prevents CUDA OOM during evaluation.
* Makes `return_y=True` safe for large datasets.
* Ensures predictable GPU memory behavior.
* Aligns tensor handling logic consistently across collected outputs.

This fix keeps inference stable and production-safe without altering any public-facing behavior.





