### PR TITLE
Improve error message for invalid reduction argument in groupby_apply

### DIFF
--- a/pytorch_forecasting/data/timeseries/_timeseries.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries.py
@@ -209,7 +209,7 @@ class TimeSeriesDataSet(Dataset):
 
     time_idx : str
         integer typed column denoting the time index within ``data``.
-        This columns is used to determine the sequence of samples.
+        This column is used to determine the sequence of samples.
         If there are no missing observations,
         the time index should increase by ``+1`` for each subsequent sample.
         The first time_idx for each series does not necessarily
@@ -305,7 +305,7 @@ class TimeSeriesDataSet(Dataset):
         dictionary of variable names mapped to list of time steps by which the
         variable should be lagged.
         Lags can be useful to indicate seasonality to the models.
-        Useful to add if seasonalit(ies) of the data are known.,
+        Useful to add if seasonality of the data are known.,
         In this case, it is recommended to add the target variables
         with the corresponding lags to improve performance.
         Lags must be at not larger than the shortest time series as all time series
@@ -327,7 +327,7 @@ class TimeSeriesDataSet(Dataset):
 
     add_encoder_length : Union[bool, str], optional, default="auto"
         whether to add encoder length to list of static real variables.
-        Defaults to "auto", iwhich is same as
+        Defaults to "auto", which is the same as
         ``True`` iff ``min_encoder_length != max_encoder_length``.
 
     target_normalizer : torch transformer, str, list, tuple, optional, default="auto"
@@ -361,7 +361,7 @@ class TimeSeriesDataSet(Dataset):
         ``RobustScaler()`` or ``None`` for using no normalizer / normalizer
         with ``center=0`` and ``scale=1``
         (``method="identity"``).
-        Prefittet encoders will not be fit again (with the exception of the
+        Prefitted encoders will not be fit again (with the exception of the
         :py:class:`~pytorch_forecasting.data.encoders.EncoderNormalizer` that is
         fit on every encoder sequence).
 

--- a/pytorch_forecasting/utils/_utils.py
+++ b/pytorch_forecasting/utils/_utils.py
@@ -68,7 +68,11 @@ def groupby_apply(
     elif reduction == "sum":
         reduce = torch.sum
     else:
-        raise ValueError(f"Unknown reduction '{reduction}'")
+        else:
+            raise ValueError(
+                f"Unknown reduction '{reduction}'. "
+                "Expected one of {'mean', 'sum'}."
+            )
     uniques, counts = keys.unique(return_counts=True)
     groups = torch.stack(
         [reduce(item) for item in torch.split_with_sizes(values, tuple(counts))]

--- a/pytorch_forecasting/utils/_utils.py
+++ b/pytorch_forecasting/utils/_utils.py
@@ -68,11 +68,9 @@ def groupby_apply(
     elif reduction == "sum":
         reduce = torch.sum
     else:
-        else:
-            raise ValueError(
-                f"Unknown reduction '{reduction}'. "
-                "Expected one of {'mean', 'sum'}."
-            )
+        raise ValueError(
+            f"Unknown reduction '{reduction}'. Expected one of {{'mean', 'sum'}}."
+        )
     uniques, counts = keys.unique(return_counts=True)
     groups = torch.stack(
         [reduce(item) for item in torch.split_with_sizes(values, tuple(counts))]


### PR DESCRIPTION
## Description

This PR improves the error message raised when an invalid `reduction`
argument is passed to `groupby_apply`.

## Changes
- Updated ValueError message to clearly specify the valid options: {'mean', 'sum'}.

This improves debugging clarity without changing functionality.