### PR TITLE
Improve error message for invalid reduction argument in groupby_apply

### DIFF
--- a/build_tools/changelog.py
+++ b/build_tools/changelog.py
@@ -193,6 +193,6 @@ if __name__ == "__main__":
     if diff["total_commits"] != len(pulls):
         raise ValueError(
             "Something went wrong and not all PR were fetched. "
-            f'There are {len(pulls)} PRs but {diff["total_commits"]} in the diff. '
+            f"There are {len(pulls)} PRs but {diff['total_commits']} in the diff. "
             "Please verify that all PRs are included in the changelog."
         )

--- a/pytorch_forecasting/data/_tslib_data_module.py
+++ b/pytorch_forecasting/data/_tslib_data_module.py
@@ -691,8 +691,7 @@ class TslibDataModule(LightningDataModule):
 
         if total_series == 0:
             raise ValueError(
-                "The time series dataset is empty. "
-                "Please provide a non-empty dataset."
+                "The time series dataset is empty. Please provide a non-empty dataset."
             )
 
         # this is a very rudimentary way to handle the splits when

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -1035,9 +1035,9 @@ class GroupNormalizer(TorchNormalizer):
         y = self.preprocess(y)
         eps = np.finfo(np.float16).eps
         if len(self._groups) == 0:
-            assert (
-                not self.scale_by_group
-            ), "No groups are defined, i.e. `scale_by_group=[]`"
+            assert not self.scale_by_group, (
+                "No groups are defined, i.e. `scale_by_group=[]`"
+            )
             if self.method == "standard":
                 self.norm_ = {
                     "center": np.mean(y),
@@ -1086,11 +1086,13 @@ class GroupNormalizer(TorchNormalizer):
                     .assign(
                         center=lambda x: x[self._method_kwargs.get("center", 0.5)],
                         scale=lambda x: (
-                            x[self._method_kwargs.get("upper", 0.75)]
-                            - x[self._method_kwargs.get("lower", 0.25)]
-                        )
-                        / 2.0
-                        + eps,
+                            (
+                                x[self._method_kwargs.get("upper", 0.75)]
+                                - x[self._method_kwargs.get("lower", 0.25)]
+                            )
+                            / 2.0
+                            + eps
+                        ),
                     )[["center", "scale"]]
                     for g in self._groups
                 }
@@ -1134,11 +1136,13 @@ class GroupNormalizer(TorchNormalizer):
                     .assign(
                         center=lambda x: x[self._method_kwargs.get("center", 0.5)],
                         scale=lambda x: (
-                            x[self._method_kwargs.get("upper", 0.75)]
-                            - x[self._method_kwargs.get("lower", 0.25)]
-                        )
-                        / 2.0
-                        + eps,
+                            (
+                                x[self._method_kwargs.get("upper", 0.75)]
+                                - x[self._method_kwargs.get("lower", 0.25)]
+                            )
+                            / 2.0
+                            + eps
+                        ),
                     )[["center", "scale"]]
                 )
             if not self.center:  # swap center and scale
@@ -1274,9 +1278,9 @@ class GroupNormalizer(TorchNormalizer):
         else:
             # filter group names
             group_names = [name for name in group_names if name in self._groups]
-        assert len(group_names) == len(
-            self._groups
-        ), "Passed groups and fitted do not match"
+        assert len(group_names) == len(self._groups), (
+            "Passed groups and fitted do not match"
+        )
 
         if len(self._groups) == 0:
             params = np.array([self.norm_["center"], self.norm_["scale"]])

--- a/pytorch_forecasting/data/tests/test_tslib_data_module.py
+++ b/pytorch_forecasting/data/tests/test_tslib_data_module.py
@@ -328,17 +328,17 @@ def test_create_windows(tslib_data_module):
 
         assert isinstance(start_idx, int), "start_idx should be an integer."
 
-        assert (
-            context_length == tslib_data_module.context_length
-        ), "context_length should match the datamodule's context_length."
+        assert context_length == tslib_data_module.context_length, (
+            "context_length should match the datamodule's context_length."
+        )
 
-        assert (
-            prediction_length == tslib_data_module.prediction_length
-        ), "prediction_length should match the datamodule's prediction_length."
+        assert prediction_length == tslib_data_module.prediction_length, (
+            "prediction_length should match the datamodule's prediction_length."
+        )
 
-        assert (
-            0 <= series_idx < len(tslib_data_module.time_series_dataset)
-        ), "series_idx should be within the range of the dataset length."
+        assert 0 <= series_idx < len(tslib_data_module.time_series_dataset), (
+            "series_idx should be within the range of the dataset length."
+        )
 
         min_required_length = context_length + prediction_length
 
@@ -352,15 +352,15 @@ def test_create_windows(tslib_data_module):
             series_length = len(sample["y"])
         else:
             series_length = len(sample)
-        assert (
-            start_idx + min_required_length <= series_length
-        ), "Window extended beyond series length."
+        assert start_idx + min_required_length <= series_length, (
+            "Window extended beyond series length."
+        )
 
     all_indices = torch.arange(len(tslib_data_module.time_series_dataset))
     all_windows = tslib_data_module._create_windows(all_indices)
-    assert len(all_windows) >= len(
-        train_windows
-    ), "Should have more windows than all indices."
+    assert len(all_windows) >= len(train_windows), (
+        "Should have more windows than all indices."
+    )
 
     empty_windows = tslib_data_module._create_windows(torch.tensor([]))
 
@@ -439,9 +439,9 @@ def test_different_split_ratios(sample_timeseries_data):
         + len(dm_custom._val_indices)
         + len(dm_custom._test_indices)
     )
-    assert (
-        total_split == total_series
-    ), "Total split indices should match the dataset length."
+    assert total_split == total_series, (
+        "Total split indices should match the dataset length."
+    )
 
 
 def test_preprocess_data(tslib_data_module, sample_timeseries_data):
@@ -527,6 +527,6 @@ def test_multivariate_target():
 
     x, y = dm.train_dataset[0]
 
-    assert (
-        y.shape[-1] == 2
-    ), "Target should have two dimensions for n_features for multivariate target."
+    assert y.shape[-1] == 2, (
+        "Target should have two dimensions for n_features for multivariate target."
+    )

--- a/pytorch_forecasting/data/timeseries/_timeseries.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries.py
@@ -579,9 +579,9 @@ class TimeSeriesDataSet(Dataset):
 
         # add time index relative to prediction position
         if self.add_relative_time_idx:
-            assert (
-                "relative_time_idx" not in data.columns
-            ), "relative_time_idx is a protected column and must not be present in data"
+            assert "relative_time_idx" not in data.columns, (
+                "relative_time_idx is a protected column and must not be present in data"
+            )
             if (
                 "relative_time_idx" not in self._time_varying_known_reals
                 and "relative_time_idx" not in self.reals
@@ -590,9 +590,9 @@ class TimeSeriesDataSet(Dataset):
 
         # add decoder length to static real variables
         if self.add_encoder_length:
-            assert (
-                "encoder_length" not in data.columns
-            ), "encoder_length is a protected column and must not be present in data"
+            assert "encoder_length" not in data.columns, (
+                "encoder_length is a protected column and must not be present in data"
+            )
             if (
                 "encoder_length" not in self._time_varying_known_reals
                 and "encoder_length" not in self.reals
@@ -623,8 +623,10 @@ class TimeSeriesDataSet(Dataset):
             # filtering for min_prediction_idx will be done on subsequence level,
             # ensuring that minimal decoder index is always >= min_prediction_idx
             data = data[
-                lambda x: x[self.time_idx]
-                >= self.min_prediction_idx - self.max_encoder_length - self.max_lag
+                lambda x: (
+                    x[self.time_idx]
+                    >= self.min_prediction_idx - self.max_encoder_length - self.max_lag
+                )
             ]
         data = data.sort_values(self.group_ids + [self.time_idx])
 
@@ -653,27 +655,27 @@ class TimeSeriesDataSet(Dataset):
 
     def _check_params(self):
         """Check parameters of self against assumptions."""
-        assert isinstance(
-            self.max_encoder_length, int
-        ), "max encoder length must be integer"
-        assert (
-            self.min_encoder_length <= self.max_encoder_length
-        ), "max encoder length has to be larger equals min encoder length"
-        assert isinstance(
-            self.min_encoder_length, int
-        ), "min encoder length must be integer"
-        assert isinstance(
-            self.max_prediction_length, int
-        ), "max prediction length must be integer"
-        assert (
-            self.min_prediction_length <= self.max_prediction_length
-        ), "max prediction length has to be larger equals min prediction length"
-        assert (
-            self.min_prediction_length > 0
-        ), "min prediction length must be larger than 0"
-        assert isinstance(
-            self.min_prediction_length, int
-        ), "min prediction length must be integer"
+        assert isinstance(self.max_encoder_length, int), (
+            "max encoder length must be integer"
+        )
+        assert self.min_encoder_length <= self.max_encoder_length, (
+            "max encoder length has to be larger equals min encoder length"
+        )
+        assert isinstance(self.min_encoder_length, int), (
+            "min encoder length must be integer"
+        )
+        assert isinstance(self.max_prediction_length, int), (
+            "max prediction length must be integer"
+        )
+        assert self.min_prediction_length <= self.max_prediction_length, (
+            "max prediction length has to be larger equals min prediction length"
+        )
+        assert self.min_prediction_length > 0, (
+            "min prediction length must be larger than 0"
+        )
+        assert isinstance(self.min_prediction_length, int), (
+            "min prediction length must be integer"
+        )
         msg = (
             f"add_encoder_length should be boolean or 'auto' "
             f"but found {self.add_encoder_length}"
@@ -681,9 +683,9 @@ class TimeSeriesDataSet(Dataset):
         assert isinstance(self.add_encoder_length, bool), msg
 
         for target in self.target_names:
-            assert (
-                target not in self._time_varying_known_reals
-            ), f"target {target} should be an unknown continuous variable in the future"
+            assert target not in self._time_varying_known_reals, (
+                f"target {target} should be an unknown continuous variable in the future"
+            )
 
         assert self.min_lag > 0, "lags should be positive"
 
@@ -998,9 +1000,9 @@ class TimeSeriesDataSet(Dataset):
 
     def _validate_data(self, data: pd.DataFrame) -> None:
         """Validate assumptions on data.."""
-        assert (
-            data[self.time_idx].dtype.kind == "i"
-        ), "Timeseries index should be of type integer"
+        assert data[self.time_idx].dtype.kind == "i", (
+            "Timeseries index should be of type integer"
+        )
         # numeric categoricals which can cause issues in tensorborad logging
         category_columns = data.head(1).select_dtypes("category").columns
         object_columns = data.head(1).select_dtypes(object).columns
@@ -1148,9 +1150,9 @@ class TimeSeriesDataSet(Dataset):
                 )
 
         # save special variables
-        assert (
-            "__time_idx__" not in data.columns
-        ), "__time_idx__ is a protected column and must not be present in data"
+        assert "__time_idx__" not in data.columns, (
+            "__time_idx__ is a protected column and must not be present in data"
+        )
         data["__time_idx__"] = data[self.time_idx]  # save unscaled
         for target in self.target_names:
             msg = (
@@ -1823,12 +1825,14 @@ class TimeSeriesDataSet(Dataset):
         # filter too short sequences
         df_index = df_index[
             # sequence must be at least of minimal prediction length
-            lambda x: (x.sequence_length >= min_sequence_length)
-            &
-            # prediction must be for minimal prediction index + length of prediction
-            (
-                x["sequence_length"] + x["time"]
-                >= self.min_prediction_idx + self.min_prediction_length
+            lambda x: (
+                (x.sequence_length >= min_sequence_length)
+                &
+                # prediction must be for minimal prediction index + length of prediction
+                (
+                    x["sequence_length"] + x["time"]
+                    >= self.min_prediction_idx + self.min_prediction_length
+                )
             )
         ]
 
@@ -1838,8 +1842,10 @@ class TimeSeriesDataSet(Dataset):
             # filter all elements that are longer
             # than the allowed maximum sequence length
             df_index = df_index[
-                lambda x: (x["time_last"] - x["time"] + 1 <= max_sequence_length)
-                & (x["sequence_length"] >= min_sequence_length)
+                lambda x: (
+                    (x["time_last"] - x["time"] + 1 <= max_sequence_length)
+                    & (x["sequence_length"] >= min_sequence_length)
+                )
             ]
             # choose longest sequence
             df_index = df_index.loc[
@@ -1950,12 +1956,14 @@ class TimeSeriesDataSet(Dataset):
                 time_idx_first=self.data["time"][index_start].numpy(),
                 time_idx_last=self.data["time"][index_last].numpy(),
                 # prediction index is last time index - decoder length + 1
-                time_idx_first_prediction=lambda x: x.time_idx_last
-                - self.calculate_decoder_length(
-                    time_last=x.time_idx_last,
-                    sequence_length=x.time_idx_last - x.time_idx_first + 1,
-                )
-                + 1,
+                time_idx_first_prediction=lambda x: (
+                    x.time_idx_last
+                    - self.calculate_decoder_length(
+                        time_last=x.time_idx_last,
+                        sequence_length=x.time_idx_last - x.time_idx_first + 1,
+                    )
+                    + 1
+                ),
             )
         )
         return index
@@ -2136,9 +2144,9 @@ class TimeSeriesDataSet(Dataset):
         # fill in missing values (if not all time indices are specified)
         sequence_length = len(time)
         if sequence_length < index.sequence_length:
-            assert (
-                self.allow_missing_timesteps
-            ), "allow_missing_timesteps should be True if sequences have gaps"
+            assert self.allow_missing_timesteps, (
+                "allow_missing_timesteps should be True if sequences have gaps"
+            )
             repetitions = torch.cat(
                 [time[1:] - time[:-1], torch.ones(1, dtype=time.dtype)]
             )
@@ -2187,18 +2195,18 @@ class TimeSeriesDataSet(Dataset):
             sequence_length = len(target[0])
 
         # determine data window
-        assert (
-            sequence_length >= self.min_prediction_length
-        ), "Sequence length should be at least minimum prediction length"
+        assert sequence_length >= self.min_prediction_length, (
+            "Sequence length should be at least minimum prediction length"
+        )
         # determine prediction/decode length and encode length
         decoder_length = self.calculate_decoder_length(time[-1], sequence_length)
         encoder_length = sequence_length - decoder_length
-        assert (
-            decoder_length >= self.min_prediction_length
-        ), "Decoder length should be at least minimum prediction length"
-        assert (
-            encoder_length >= self.min_encoder_length
-        ), "Encoder length should be at least minimum encoder length"
+        assert decoder_length >= self.min_prediction_length, (
+            "Decoder length should be at least minimum prediction length"
+        )
+        assert encoder_length >= self.min_encoder_length, (
+            "Encoder length should be at least minimum encoder length"
+        )
 
         if self.randomize_length is not None:  # randomization improves generalization
             # modify encode and decode lengths

--- a/pytorch_forecasting/layers/_recurrent/_mlstm/cell.py
+++ b/pytorch_forecasting/layers/_recurrent/_mlstm/cell.py
@@ -94,9 +94,9 @@ class mLSTMCell(nn.Module):
         """
 
         batch_size = x.size(0)
-        assert (
-            x.dim() == 2
-        ), f"Input should be 2D (batch_size, input_size), got {x.dim()}D"
+        assert x.dim() == 2, (
+            f"Input should be 2D (batch_size, input_size), got {x.dim()}D"
+        )
         assert h_prev.size() == (
             batch_size,
             self.hidden_size,

--- a/pytorch_forecasting/metrics/base_metrics/_base_metrics.py
+++ b/pytorch_forecasting/metrics/base_metrics/_base_metrics.py
@@ -100,9 +100,9 @@ class Metric(LightningMetric):
         """
         if y_pred.ndim == 3:
             if self.quantiles is None:
-                assert (
-                    y_pred.size(-1) == 1
-                ), "Prediction should only have one extra dimension"
+                assert y_pred.size(-1) == 1, (
+                    "Prediction should only have one extra dimension"
+                )
                 y_pred = y_pred[..., 0]
             else:
                 y_pred = y_pred.mean(-1)
@@ -282,9 +282,9 @@ class MultiLoss(LightningMetric):
         assert len(metrics) > 0, "at least one metric has to be specified"
         if weights is None:
             weights = [1.0 for _ in metrics]
-        assert len(weights) == len(
-            metrics
-        ), "Number of weights has to match number of metrics"
+        assert len(weights) == len(metrics), (
+            "Number of weights has to match number of metrics"
+        )
 
         self.metrics = [
             convert_torchmetric_to_pytorch_forecasting_metric(m) for m in metrics
@@ -561,9 +561,9 @@ class CompositeMetric(LightningMetric):
             metrics = []
         if weights is None:
             weights = [1.0 for _ in metrics]
-        assert len(weights) == len(
-            metrics
-        ), "Number of weights has to match number of metrics"
+        assert len(weights) == len(metrics), (
+            "Number of weights has to match number of metrics"
+        )
 
         self._metrics = list(metrics)
         self._weights = list(weights)

--- a/pytorch_forecasting/metrics/distributions.py
+++ b/pytorch_forecasting/metrics/distributions.py
@@ -250,9 +250,9 @@ class LogNormalDistributionLoss(DistributionLoss):
             f" `transformation={encoder.transform}`"
         )
 
-        assert encoder.transformation not in [
-            "logit"
-        ], "Cannot use bound transformation such as 'logit'"
+        assert encoder.transformation not in ["logit"], (
+            "Cannot use bound transformation such as 'logit'"
+        )
 
         scale = F.softplus(parameters[..., 1]) * target_scale[..., 1].unsqueeze(-1)
         loc = parameters[..., 0] * target_scale[..., 1].unsqueeze(-1) + target_scale[
@@ -303,9 +303,9 @@ class BetaDistributionLoss(DistributionLoss):
         target_scale: torch.Tensor,
         encoder: BaseEstimator,
     ) -> torch.Tensor:
-        assert encoder.transformation in [
-            "logit"
-        ], "Beta distribution is only compatible with logit transformation"
+        assert encoder.transformation in ["logit"], (
+            "Beta distribution is only compatible with logit transformation"
+        )
         assert encoder.center, "Beta distribution requires normalizer to center data"
 
         scaled_mean = encoder(

--- a/pytorch_forecasting/metrics/point.py
+++ b/pytorch_forecasting/metrics/point.py
@@ -255,9 +255,9 @@ class MASE(MultiHorizonMetric):
         eps = 1e-6
         batch_size = target.size(0)
         total_lengths = lengths + encoder_lengths
-        assert (
-            total_lengths > 1
-        ).all(), "Need at least 2 target values to be able to calculate MASE"
+        assert (total_lengths > 1).all(), (
+            "Need at least 2 target values to be able to calculate MASE"
+        )
         max_length = target.size(1) + encoder_target.size(1)
         if (
             total_lengths != max_length

--- a/pytorch_forecasting/metrics/tests/test_all_metrics.py
+++ b/pytorch_forecasting/metrics/tests/test_all_metrics.py
@@ -359,9 +359,9 @@ class TestAllPtMetrics(MetricPackageConfig, MetricFixtureGenerator):
             quantile_pred = metric.to_quantiles(y_pred)
             # for quantile metrics, the original predictions should match the result of
             # `to_quantiles`, since it does not take in the `quantiles` argument.
-            assert torch.allclose(
-                quantile_pred, y_pred
-            ), f"Quantile prediction does not match the original predictions in {metric_type}."  # noqa: E501
+            assert torch.allclose(quantile_pred, y_pred), (
+                f"Quantile prediction does not match the original predictions in {metric_type}."
+            )  # noqa: E501
 
             expected_shape = self._get_expected_output_shape_quantiles(
                 batch_size, prediction_length, output_dim, metric_type
@@ -374,9 +374,9 @@ class TestAllPtMetrics(MetricPackageConfig, MetricFixtureGenerator):
                 batch_size, prediction_length, len(quantiles), metric_type
             )
 
-        assert isinstance(
-            quantile_pred, torch.Tensor
-        ), "Quantile prediction should be a tensor."  # noqa: E501
+        assert isinstance(quantile_pred, torch.Tensor), (
+            "Quantile prediction should be a tensor."
+        )  # noqa: E501
         assert quantile_pred.shape == expected_shape, (
             f"Quantile prediction shape mismatch: got {quantile_pred.shape}, "
             f"expected {expected_shape}."
@@ -487,9 +487,9 @@ class TestAllPtMetrics(MetricPackageConfig, MetricFixtureGenerator):
         else:
             assert result.ndim == 0
             if reduction == "sqrt-mean":
-                assert (
-                    result >= 0
-                ), "Result should be non-negative for sqrt-mean reduction."  # noqa: E501
+                assert result >= 0, (
+                    "Result should be non-negative for sqrt-mean reduction."
+                )  # noqa: E501
 
     @pytest.mark.parametrize("target_type", ["standard", "packed", "weighted"])
     def test_loss_method(
@@ -544,9 +544,9 @@ class TestAllPtMetrics(MetricPackageConfig, MetricFixtureGenerator):
             ), "Distribution Loss should match for the first two dimensions."  # noqa: E501
             assert res.ndim == 2, "Distribution loss return should be a 2D tensor."  # noqa: E501
         else:
-            assert (
-                res.ndim == y_pred.ndim
-            ), "Loss should have the same number of dimensions as predictions."  # noqa: E501
-            assert (
-                res.shape == y_pred.shape
-            ), f"Loss should be a tensor with shape {y_pred.shape}, got {res.shape}."  # noqa: E501
+            assert res.ndim == y_pred.ndim, (
+                "Loss should have the same number of dimensions as predictions."
+            )  # noqa: E501
+            assert res.shape == y_pred.shape, (
+                f"Loss should be a tensor with shape {y_pred.shape}, got {res.shape}."
+            )  # noqa: E501

--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -1543,13 +1543,13 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
             kwargs["dataset_parameters"] = dataset.get_parameters()
         net = cls(**kwargs)
         if dataset.multi_target:
-            assert isinstance(
-                net.loss, MultiLoss
-            ), f"multiple targets require loss to be MultiLoss but found {net.loss}"
+            assert isinstance(net.loss, MultiLoss), (
+                f"multiple targets require loss to be MultiLoss but found {net.loss}"
+            )
         else:
-            assert not isinstance(
-                net.loss, MultiLoss
-            ), "MultiLoss not compatible with single target"
+            assert not isinstance(net.loss, MultiLoss), (
+                "MultiLoss not compatible with single target"
+            )
 
         return net
 
@@ -1718,9 +1718,9 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
             mode_kwargs = {}
 
         # ensure passed dataloader is correct
-        assert isinstance(
-            dataloader.dataset, TimeSeriesDataSet
-        ), "dataset behind dataloader mut be TimeSeriesDataSet"
+        assert isinstance(dataloader.dataset, TimeSeriesDataSet), (
+            "dataset behind dataloader mut be TimeSeriesDataSet"
+        )
 
         predict_callback = PredictCallback(
             mode=mode,
@@ -2392,9 +2392,9 @@ class AutoRegressiveBaseModel(BaseModel):
         target0 = dataset.target_names[0]
         lag = set(lags.get(target0, []))
         for target in dataset.target_names:
-            assert lag == set(
-                lags.get(target, [])
-            ), f"all target lags in dataset must be the same but found {lags}"
+            assert lag == set(lags.get(target, [])), (
+                f"all target lags in dataset must be the same but found {lags}"
+            )
 
         kwargs.setdefault(
             "target_lags", {name: dataset._get_lagged_names(name) for name in lags}

--- a/pytorch_forecasting/models/baseline.py
+++ b/pytorch_forecasting/models/baseline.py
@@ -65,9 +65,9 @@ class Baseline(BaseModel):
         encoder_target: torch.Tensor,
     ):
         max_prediction_length = decoder_lengths.max()
-        assert (
-            encoder_lengths.min() > 0
-        ), "Encoder lengths of at least 1 required to obtain last value"
+        assert encoder_lengths.min() > 0, (
+            "Encoder lengths of at least 1 required to obtain last value"
+        )
         last_values = encoder_target[
             torch.arange(encoder_target.size(0)), encoder_lengths - 1
         ]

--- a/pytorch_forecasting/models/deepar/_deepar.py
+++ b/pytorch_forecasting/models/deepar/_deepar.py
@@ -172,9 +172,9 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
             " the same apart from target variable"
         )
         for targeti in to_list(target):
-            assert (
-                targeti in time_varying_reals_encoder
-            ), f"target {targeti} has to be real"  # todo: remove this restriction
+            assert targeti in time_varying_reals_encoder, (
+                f"target {targeti} has to be real"
+            )  # todo: remove this restriction
         assert (isinstance(target, str) and isinstance(loss, DistributionLoss)) or (
             isinstance(target, tuple | list)
             and isinstance(loss, MultiLoss)
@@ -231,22 +231,19 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
                 MultiLoss([NormalDistributionLoss()] * len(dataset.target_names)),
             )
         new_kwargs.update(kwargs)
-        assert (
-            not isinstance(dataset.target_normalizer, NaNLabelEncoder)
-            and (
-                not isinstance(dataset.target_normalizer, MultiNormalizer)
-                or all(
-                    not isinstance(normalizer, NaNLabelEncoder)
-                    for normalizer in dataset.target_normalizer
-                )
+        assert not isinstance(dataset.target_normalizer, NaNLabelEncoder) and (
+            not isinstance(dataset.target_normalizer, MultiNormalizer)
+            or all(
+                not isinstance(normalizer, NaNLabelEncoder)
+                for normalizer in dataset.target_normalizer
             )
         ), (
             "target(s) should be continuous - categorical targets are not supported"
         )  # todo: remove this restriction # noqa: E501
         if isinstance(new_kwargs.get("loss", None), MultivariateDistributionLoss):
-            assert (
-                dataset.min_prediction_length == dataset.max_prediction_length
-            ), "Multivariate models require constant prediction lengths"
+            assert dataset.min_prediction_length == dataset.max_prediction_length, (
+                "Multivariate models require constant prediction lengths"
+            )
         return super().from_dataset(
             dataset,
             allowed_encoder_known_variable_names=allowed_encoder_known_variable_names,

--- a/pytorch_forecasting/models/nbeats/_nbeats_adapter.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_adapter.py
@@ -138,12 +138,12 @@ class NBeatsAdapter(BaseModel):
         new_kwargs.update(kwargs)
 
         # validate arguments
-        assert isinstance(
-            dataset.target, str
-        ), "only one target is allowed (passed as string to dataset)"
-        assert not isinstance(
-            dataset.target_normalizer, NaNLabelEncoder
-        ), "only regression tasks are supported - target must not be categorical"
+        assert isinstance(dataset.target, str), (
+            "only one target is allowed (passed as string to dataset)"
+        )
+        assert not isinstance(dataset.target_normalizer, NaNLabelEncoder), (
+            "only regression tasks are supported - target must not be categorical"
+        )
         assert dataset.min_encoder_length == dataset.max_encoder_length, (
             "only fixed encoder length is allowed,"
             " but min_encoder_length != max_encoder_length"
@@ -154,12 +154,12 @@ class NBeatsAdapter(BaseModel):
             " but max_prediction_length != min_prediction_length"
         )
 
-        assert (
-            dataset.randomize_length is None
-        ), "length has to be fixed, but randomize_length is not None"
-        assert (
-            not dataset.add_relative_time_idx
-        ), "add_relative_time_idx has to be False"
+        assert dataset.randomize_length is None, (
+            "length has to be fixed, but randomize_length is not None"
+        )
+        assert not dataset.add_relative_time_idx, (
+            "add_relative_time_idx has to be False"
+        )
 
         assert (
             len(dataset.flat_categoricals) == 0

--- a/pytorch_forecasting/models/nhits/_nhits.py
+++ b/pytorch_forecasting/models/nhits/_nhits.py
@@ -413,9 +413,9 @@ class NHiTS(BaseModelWithCovariates):
             NHiTS
         """  # noqa: E501
         # validate arguments
-        assert not isinstance(
-            dataset.target_normalizer, NaNLabelEncoder
-        ), "only regression tasks are supported - target must not be categorical"
+        assert not isinstance(dataset.target_normalizer, NaNLabelEncoder), (
+            "only regression tasks are supported - target must not be categorical"
+        )
         assert dataset.min_encoder_length == dataset.max_encoder_length, (
             "only fixed encoder length is allowed,"
             " but min_encoder_length != max_encoder_length"
@@ -426,12 +426,12 @@ class NHiTS(BaseModelWithCovariates):
             " but max_prediction_length != min_prediction_length"
         )
 
-        assert (
-            dataset.randomize_length is None
-        ), "length has to be fixed, but randomize_length is not None"
-        assert (
-            not dataset.add_relative_time_idx
-        ), "add_relative_time_idx has to be False"
+        assert dataset.randomize_length is None, (
+            "length has to be fixed, but randomize_length is not None"
+        )
+        assert not dataset.add_relative_time_idx, (
+            "add_relative_time_idx has to be False"
+        )
 
         new_kwargs = copy(kwargs)
         new_kwargs.update(

--- a/pytorch_forecasting/models/nn/embeddings.py
+++ b/pytorch_forecasting/models/nn/embeddings.py
@@ -90,9 +90,9 @@ class MultiEmbedding(nn.Module):
                 name for names in categorical_groups.values() for name in names
             ]
             if len(categorical_groups) > 0:
-                assert all(
-                    name in embedding_sizes for name in categorical_groups
-                ), "categorical_groups must be in embedding_sizes."
+                assert all(name in embedding_sizes for name in categorical_groups), (
+                    "categorical_groups must be in embedding_sizes."
+                )
                 assert not any(
                     name in embedding_sizes for name in categorical_group_variables
                 ), (
@@ -111,9 +111,9 @@ class MultiEmbedding(nn.Module):
                 "but only if not already in categorical_groups."
             )
         else:
-            assert (
-                x_categoricals is None and len(categorical_groups) == 0
-            ), "If embedding_sizes is not a dictionary, categorical_groups and x_categoricals must be empty."  # noqa: E501
+            assert x_categoricals is None and len(categorical_groups) == 0, (
+                "If embedding_sizes is not a dictionary, categorical_groups and x_categoricals must be empty."
+            )  # noqa: E501
             # number embeddings based on order
             embedding_sizes = {
                 str(name): size for name, size in enumerate(embedding_sizes)

--- a/pytorch_forecasting/models/nn/rnn.py
+++ b/pytorch_forecasting/models/nn/rnn.py
@@ -94,9 +94,9 @@ class RNN(ABC, nn.RNNBase):
                 Output is packed sequence if input has been a packed sequence.
         """  # noqa: E501
         if isinstance(x, rnn.PackedSequence) or lengths is None:
-            assert (
-                lengths is None
-            ), "cannot combine x of type PackedSequence with lengths argument"
+            assert lengths is None, (
+                "cannot combine x of type PackedSequence with lengths argument"
+            )
             return super().forward(x, hx=hx)
         else:
             min_length = lengths.min()

--- a/pytorch_forecasting/models/rnn/_rnn.py
+++ b/pytorch_forecasting/models/rnn/_rnn.py
@@ -148,9 +148,9 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
             " be the same apart from target variable"
         )
         for targeti in to_list(target):
-            assert (
-                targeti in time_varying_reals_encoder
-            ), f"target {targeti} has to be real"  # todo: remove this restriction
+            assert targeti in time_varying_reals_encoder, (
+                f"target {targeti} has to be real"
+            )  # todo: remove this restriction
         assert (isinstance(target, str) and isinstance(loss, MultiHorizonMetric)) or (
             isinstance(target, tuple | list)
             and isinstance(loss, MultiLoss)
@@ -174,9 +174,9 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
             self.output_projector = nn.Linear(
                 self.hparams.hidden_size, self.hparams.output_size
             )
-            assert not isinstance(
-                self.loss, QuantileLoss
-            ), "QuantileLoss does not work with recurrent network"
+            assert not isinstance(self.loss, QuantileLoss), (
+                "QuantileLoss does not work with recurrent network"
+            )
         else:  # multi target
             self.output_projector = nn.ModuleList(
                 [
@@ -185,9 +185,9 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
                 ]
             )
             for l in self.loss:
-                assert not isinstance(
-                    l, QuantileLoss
-                ), "QuantileLoss does not work with recurrent network"
+                assert not isinstance(l, QuantileLoss), (
+                    "QuantileLoss does not work with recurrent network"
+                )
 
     @classmethod
     def from_dataset(
@@ -213,14 +213,11 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
                 dataset=dataset, kwargs=kwargs, default_loss=MAE()
             )
         )
-        assert (
-            not isinstance(dataset.target_normalizer, NaNLabelEncoder)
-            and (
-                not isinstance(dataset.target_normalizer, MultiNormalizer)
-                or all(
-                    not isinstance(normalizer, NaNLabelEncoder)
-                    for normalizer in dataset.target_normalizer
-                )
+        assert not isinstance(dataset.target_normalizer, NaNLabelEncoder) and (
+            not isinstance(dataset.target_normalizer, MultiNormalizer)
+            or all(
+                not isinstance(normalizer, NaNLabelEncoder)
+                for normalizer in dataset.target_normalizer
             )
         ), (
             "target(s) should be continuous - categorical targets are not supported"

--- a/pytorch_forecasting/models/temporal_fusion_transformer/_tft.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/_tft.py
@@ -205,9 +205,9 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             loss = QuantileLoss()
         self.save_hyperparameters()
         # store loss function separately as it is a module
-        assert isinstance(
-            loss, LightningMetric
-        ), "Loss has to be a PyTorch Lightning `Metric`"
+        assert isinstance(loss, LightningMetric), (
+            "Loss has to be a PyTorch Lightning `Metric`"
+        )
         super().__init__(loss=loss, logging_metrics=logging_metrics, **kwargs)
 
         # processing inputs

--- a/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
@@ -414,9 +414,9 @@ class VariableSelectionNetwork(nn.Module):
 class PositionalEncoder(torch.nn.Module):
     def __init__(self, d_model, max_seq_len=160):
         super().__init__()
-        assert (
-            d_model % 2 == 0
-        ), "model dimension has to be multiple of 2 (encode sin(pos) and cos(pos))"
+        assert d_model % 2 == 0, (
+            "model dimension has to be multiple of 2 (encode sin(pos) and cos(pos))"
+        )
         self.d_model = d_model
         pe = torch.zeros(max_seq_len, d_model)
         for pos in range(max_seq_len):

--- a/pytorch_forecasting/models/tide/_tide.py
+++ b/pytorch_forecasting/models/tide/_tide.py
@@ -237,9 +237,9 @@ class TiDEModel(BaseModelWithCovariates):
         """
 
         # validate arguments
-        assert not isinstance(
-            dataset.target_normalizer, NaNLabelEncoder
-        ), "only regression tasks are supported - target must not be categorical"
+        assert not isinstance(dataset.target_normalizer, NaNLabelEncoder), (
+            "only regression tasks are supported - target must not be categorical"
+        )
 
         assert dataset.min_encoder_length == dataset.max_encoder_length, (
             "only fixed encoder length is allowed,"
@@ -251,12 +251,12 @@ class TiDEModel(BaseModelWithCovariates):
             " but max_prediction_length != min_prediction_length"
         )
 
-        assert (
-            dataset.randomize_length is None
-        ), "length has to be fixed, but randomize_length is not None"
-        assert (
-            not dataset.add_relative_time_idx
-        ), "add_relative_time_idx has to be False"
+        assert dataset.randomize_length is None, (
+            "length has to be fixed, but randomize_length is not None"
+        )
+        assert not dataset.add_relative_time_idx, (
+            "add_relative_time_idx has to be False"
+        )
 
         new_kwargs = copy(kwargs)
         new_kwargs.update(

--- a/pytorch_forecasting/models/xlstm/_xlstm.py
+++ b/pytorch_forecasting/models/xlstm/_xlstm.py
@@ -167,9 +167,9 @@ class xLSTMTime(AutoRegressiveBaseModel):
         """
         from pytorch_forecasting.data.encoders import NaNLabelEncoder
 
-        assert not isinstance(
-            dataset.target_normalizer, NaNLabelEncoder
-        ), "only regression tasks are supported - target must not be categorical"
+        assert not isinstance(dataset.target_normalizer, NaNLabelEncoder), (
+            "only regression tasks are supported - target must not be categorical"
+        )
 
         new_kwargs = copy(kwargs)
         new_kwargs.update(

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -340,9 +340,9 @@ def _integration(
 
         batch_size, prediction_length, n_features = output.shape
         assert batch_size > 0, f"Batch size must be positive, got {batch_size}"
-        assert (
-            prediction_length > 0
-        ), f"Prediction length must be positive, got {prediction_length}"
+        assert prediction_length > 0, (
+            f"Prediction length must be positive, got {prediction_length}"
+        )
         assert (
             # todo: compare n_features with expected 3rd dimension of the corresponding
             # loss function on which model is trained and

--- a/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
+++ b/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
@@ -59,9 +59,9 @@ class TestAllPtForecastersV2(EstimatorPackageConfig, EstimatorFixtureGenerator):
         assert os.path.exists(best_model_path)
 
         dm_cfg_path = Path(best_model_path).parent / "model_cfg.pkl"
-        assert (
-            dm_cfg_path.exists()
-        ), "datamodule_cfg.pkl was not saved alongside checkpoint"
+        assert dm_cfg_path.exists(), (
+            "datamodule_cfg.pkl was not saved alongside checkpoint"
+        )
 
         pkg_loaded = object_pkg(ckpt_path=best_model_path)
 
@@ -82,17 +82,17 @@ class TestAllPtForecastersV2(EstimatorPackageConfig, EstimatorFixtureGenerator):
         raw_out = pkg.predict(predict_data, mode="raw")
         raw_pred_tensor = raw_out["prediction"]
         assert any(isinstance(v, torch.Tensor) for v in raw_out.values())
-        assert (
-            raw_pred_tensor.ndim == 3
-        ), f"Prediction must be 3D, got {raw_pred_tensor.ndim}D"
+        assert raw_pred_tensor.ndim == 3, (
+            f"Prediction must be 3D, got {raw_pred_tensor.ndim}D"
+        )
 
         # mode="quantiles"
         quantile_out = pkg.predict(predict_data, mode="quantiles")
         quanitle_pred_tensor = quantile_out["prediction"]
         assert isinstance(quanitle_pred_tensor, torch.Tensor)
-        assert (
-            quanitle_pred_tensor.ndim == 3
-        ), f"Prediction must be 3D, got {quanitle_pred_tensor.ndim}D"
+        assert quanitle_pred_tensor.ndim == 3, (
+            f"Prediction must be 3D, got {quanitle_pred_tensor.ndim}D"
+        )
 
         # mode="prediction"
         pred_out = pkg.predict(predict_data, mode="prediction")

--- a/pytorch_forecasting/utils/_utils.py
+++ b/pytorch_forecasting/utils/_utils.py
@@ -69,7 +69,7 @@ def groupby_apply(
         reduce = torch.sum
     else:
         raise ValueError(
-            f"Unknown reduction '{reduction}'. " "Expected one of {'mean', 'sum'}."
+            f"Unknown reduction '{reduction}'. Expected one of {{'mean', 'sum'}}."
         )
     uniques, counts = keys.unique(return_counts=True)
     groups = torch.stack(

--- a/tests/test_data/test_encoders.py
+++ b/tests/test_data/test_encoders.py
@@ -37,15 +37,15 @@ def test_NaNLabelEncoder(data, allow_nan):
         with pytest.raises(KeyError):
             encoder.transform(transform_data)
     else:
-        assert (
-            encoder.transform(transform_data)[0] == 0
-        ), "First value should be translated to 0 if nan"
-        assert (
-            encoder.transform(transform_data)[-1] == 0
-        ), "Last value should be translated to 0 if nan"
-        assert (
-            encoder.transform(fit_data)[0] > 0
-        ), "First value should not be 0 if not nan"
+        assert encoder.transform(transform_data)[0] == 0, (
+            "First value should be translated to 0 if nan"
+        )
+        assert encoder.transform(transform_data)[-1] == 0, (
+            "Last value should be translated to 0 if nan"
+        )
+        assert encoder.transform(fit_data)[0] > 0, (
+            "First value should not be 0 if not nan"
+        )
 
 
 def test_NaNLabelEncoder_add():
@@ -99,9 +99,9 @@ def test_EncoderNormalizer(kwargs, data_type):
     inverse = normalizer.inverse_transform(torch.as_tensor(transformed))
 
     if kwargs.get("transformation") in ["relu", "softplus", "log1p"]:
-        assert (
-            inverse >= 0
-        ).all(), "Inverse transform should yield only positive values"
+        assert (inverse >= 0).all(), (
+            "Inverse transform should yield only positive values"
+        )
     else:
         expected = torch.as_tensor(data)
         assert torch.isclose(
@@ -145,9 +145,9 @@ def test_GroupNormalizer(kwargs, groups):
     )
 
     if kwargs.get("transformation") in ["relu", "softplus", "log1p", "log"]:
-        assert (
-            normalizer(test_data) >= 0
-        ).all(), "Inverse transform should yield only positive values"
+        assert (normalizer(test_data) >= 0).all(), (
+            "Inverse transform should yield only positive values"
+        )
     else:
         assert torch.isclose(
             normalizer(test_data), torch.tensor(data.b.iloc[0]), atol=1e-5

--- a/tests/test_data/test_timeseries.py
+++ b/tests/test_data/test_timeseries.py
@@ -61,8 +61,8 @@ def test_find_end_indices():
 def test_raise_short_encoder_length(test_data):
     with pytest.warns(UserWarning):
         test_data = test_data[
-            lambda x: ~(
-                (x.agency == "Agency_22") & (x.sku == "SKU_01") & (x.time_idx > 3)
+            lambda x: (
+                ~((x.agency == "Agency_22") & (x.sku == "SKU_01") & (x.time_idx > 3))
             )
         ]
         TimeSeriesDataSet(
@@ -109,9 +109,9 @@ def check_dataloader_output(dataset: TimeSeriesDataSet, out: dict[str, torch.Ten
             assert not torch.isnan(vi).any(), f"Values for {k} should not be nan"
 
     # check weight
-    assert y[1] is None or isinstance(
-        y[1], torch.Tensor
-    ), "weights should be none or tensor"
+    assert y[1] is None or isinstance(y[1], torch.Tensor), (
+        "weights should be none or tensor"
+    )
     if isinstance(y[1], torch.Tensor):
         assert torch.isfinite(y[1]).all(), "Values for weight should be finite"
         assert not torch.isnan(y[1]).any(), "Values for weight should not be nan"
@@ -335,9 +335,9 @@ def test_overwrite_values(test_dataset, value, variable, target):
     for name in outputs[0].keys():
         changed = torch.isclose(outputs[0][name], control_outputs[0][name]).all()
         assert changed, f"Output {name} should be reset"
-    assert torch.isclose(
-        outputs[1][0], control_outputs[1][0]
-    ).all(), "Target should be reset"
+    assert torch.isclose(outputs[1][0], control_outputs[1][0]).all(), (
+        "Target should be reset"
+    )
 
 
 @pytest.mark.parametrize(
@@ -495,9 +495,9 @@ def test_lagged_variables(test_data, kwargs):
             lag_idx = vars.index(f"{name}_lagged_by_{lag}")
             target = x[..., target_idx][:, 0]
             lagged_target = torch.roll(x[..., lag_idx], -lag, dims=1)[:, 0]
-            assert torch.isclose(
-                target, lagged_target
-            ).all(), "lagged target must be the same as non-lagged target"
+            assert torch.isclose(target, lagged_target).all(), (
+                "lagged target must be the same as non-lagged target"
+            )
 
 
 def test_lagged_variable_known_unknown_assignment(test_data):
@@ -529,51 +529,51 @@ def test_lagged_variable_known_unknown_assignment(test_data):
         for lag in [1, 2, 3]:
             lagged_name = f"{var}_lagged_by_{lag}"
             if is_known:
-                assert (
-                    lagged_name in dataset._time_varying_known_reals
-                ), f"{lagged_name} should be known real (from known real)"
-                assert (
-                    lagged_name not in dataset._time_varying_unknown_reals
-                ), f"{lagged_name} should not be unknown real (from known real)"
+                assert lagged_name in dataset._time_varying_known_reals, (
+                    f"{lagged_name} should be known real (from known real)"
+                )
+                assert lagged_name not in dataset._time_varying_unknown_reals, (
+                    f"{lagged_name} should not be unknown real (from known real)"
+                )
             else:
                 if lag >= horizon:
-                    assert (
-                        lagged_name in dataset._time_varying_known_reals
-                    ), f"{lagged_name} should be known real (lag >= horizon)"
-                    assert (
-                        lagged_name not in dataset._time_varying_unknown_reals
-                    ), f"{lagged_name} should not be unknown real (lag >= horizon)"
+                    assert lagged_name in dataset._time_varying_known_reals, (
+                        f"{lagged_name} should be known real (lag >= horizon)"
+                    )
+                    assert lagged_name not in dataset._time_varying_unknown_reals, (
+                        f"{lagged_name} should not be unknown real (lag >= horizon)"
+                    )
                 else:
-                    assert (
-                        lagged_name in dataset._time_varying_unknown_reals
-                    ), f"{lagged_name} should be unknown real (lag < horizon)"
-                    assert (
-                        lagged_name not in dataset._time_varying_known_reals
-                    ), f"{lagged_name} should not be known real (lag < horizon)"
+                    assert lagged_name in dataset._time_varying_unknown_reals, (
+                        f"{lagged_name} should be unknown real (lag < horizon)"
+                    )
+                    assert lagged_name not in dataset._time_varying_known_reals, (
+                        f"{lagged_name} should not be known real (lag < horizon)"
+                    )
 
     for var in ["agency", "month"]:
         is_known = var in dataset._time_varying_known_categoricals
         for lag in [1, 2, 3]:
             lagged_name = f"{var}_lagged_by_{lag}"
             if is_known:
-                assert (
-                    lagged_name in dataset._time_varying_known_categoricals
-                ), f"{lagged_name} should be known cat (from known cat)"
-                assert (
-                    lagged_name not in dataset._time_varying_unknown_categoricals
-                ), f"{lagged_name} should not be unknown cat (from known cat)"
+                assert lagged_name in dataset._time_varying_known_categoricals, (
+                    f"{lagged_name} should be known cat (from known cat)"
+                )
+                assert lagged_name not in dataset._time_varying_unknown_categoricals, (
+                    f"{lagged_name} should not be unknown cat (from known cat)"
+                )
             else:
                 if lag >= horizon:
-                    assert (
-                        lagged_name in dataset._time_varying_known_categoricals
-                    ), f"{lagged_name} should be known cat (lag >= horizon)"
+                    assert lagged_name in dataset._time_varying_known_categoricals, (
+                        f"{lagged_name} should be known cat (lag >= horizon)"
+                    )
                     assert (
                         lagged_name not in dataset._time_varying_unknown_categoricals
                     ), f"{lagged_name} should not be unknown cat (lag >= horizon)"
                 else:
-                    assert (
-                        lagged_name in dataset._time_varying_unknown_categoricals
-                    ), f"{lagged_name} should be unknown cat (lag < horizon)"
+                    assert lagged_name in dataset._time_varying_unknown_categoricals, (
+                        f"{lagged_name} should be unknown cat (lag < horizon)"
+                    )
                     assert (
                         lagged_name not in dataset._time_varying_known_categoricals
                     ), f"{lagged_name} should not be known cat (lag < horizon)"
@@ -589,23 +589,23 @@ def test_lagged_variable_known_unknown_assignment(test_data):
     ],
 )
 def test_filter_data(test_dataset, agency, first_prediction_idx, should_raise):
-    func = lambda x: (x.agency == agency) & (
-        x.time_idx_first_prediction >= first_prediction_idx
+    func = lambda x: (
+        (x.agency == agency) & (x.time_idx_first_prediction >= first_prediction_idx)
     )
     if should_raise:
         with pytest.raises(ValueError):
             test_dataset.filter(func)
     else:
         filtered_dataset = test_dataset.filter(func)
-        assert len(test_dataset.index) > len(
-            filtered_dataset.index
-        ), "filtered dataset should have less entries than original dataset"
+        assert len(test_dataset.index) > len(filtered_dataset.index), (
+            "filtered dataset should have less entries than original dataset"
+        )
         for x, _ in iter(filtered_dataset.to_dataloader()):
             index = test_dataset.x_to_index(x)
             assert (index["agency"] == agency).all(), "Agency filter has failed"
-            assert (
-                index["time_idx"].min() == first_prediction_idx
-            ), "First prediction filter has failed"
+            assert index["time_idx"].min() == first_prediction_idx, (
+                "First prediction filter has failed"
+            )
 
 
 def test_graph_sampler(test_dataset):
@@ -640,8 +640,9 @@ def test_graph_sampler(test_dataset):
                 selected_pos = indices["index_start"].iloc[sub_group_idx]
                 # remove selected sample
                 indices = indices[
-                    lambda x: x["sequence_id"]
-                    != indices["sequence_id"].iloc[sub_group_idx]
+                    lambda x: (
+                        x["sequence_id"] != indices["sequence_id"].iloc[sub_group_idx]
+                    )
                 ]
                 # filter duplicate timeseries
                 # indices = indices.sort_values("sequence_length").drop_duplicates("sequence_id", keep="last") # noqa : E501

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -30,9 +30,9 @@ def test_composite_metric():
     metric1 = SMAPE()
     metric2 = MAE()
     combined_metric = 1.0 * (0.3 * metric1 + 2.0 * metric2 + metric1)
-    assert isinstance(
-        combined_metric, CompositeMetric
-    ), "combined metric should be composite metric"
+    assert isinstance(combined_metric, CompositeMetric), (
+        "combined metric should be composite metric"
+    )
 
     # test repr()
     repr(combined_metric)
@@ -392,10 +392,12 @@ def mock_device(request):
             patch("torch.tensor", new=mock_tensor),
             patch(
                 "torch.Tensor.to",
-                new=lambda self, device, *args, **kwargs: self.clone()
-                if isinstance(device, str | torch.device)
-                and str(device).startswith("cuda")
-                else self,
+                new=lambda self, device, *args, **kwargs: (
+                    self.clone()
+                    if isinstance(device, str | torch.device)
+                    and str(device).startswith("cuda")
+                    else self
+                ),
             ),
             patch(
                 "torch.Tensor.device",

--- a/tests/test_models/test_nn/test_embeddings.py
+++ b/tests/test_models/test_nn/test_embeddings.py
@@ -20,20 +20,20 @@ from pytorch_forecasting import MultiEmbedding
 def test_MultiEmbedding(kwargs):
     x = torch.randint(0, 10, size=(4, 3))
     embedding = MultiEmbedding(**kwargs)
-    assert embedding.input_size == x.size(
-        1
-    ), "Input size should be equal to number of features"
+    assert embedding.input_size == x.size(1), (
+        "Input size should be equal to number of features"
+    )
     out = embedding(x)
     if isinstance(out, dict):
         assert isinstance(kwargs["embedding_sizes"], dict)
         for name, o in out.items():
-            assert (
-                o.size(1) == embedding.output_size[name]
-            ), "Output size should be equal to number of embedding dimensions"
+            assert o.size(1) == embedding.output_size[name], (
+                "Output size should be equal to number of embedding dimensions"
+            )
     elif isinstance(out, torch.Tensor):
         assert isinstance(kwargs["embedding_sizes"], tuple | list)
-        assert (
-            out.size(1) == embedding.output_size
-        ), "Output size should be equal to number of summed embedding dimensions"
+        assert out.size(1) == embedding.output_size, (
+            "Output size should be equal to number of summed embedding dimensions"
+        )
     else:
         raise ValueError(f"Unknown output type {type(out)}")

--- a/tests/test_models/test_nn/test_rnn.py
+++ b/tests/test_models/test_nn/test_rnn.py
@@ -45,9 +45,9 @@ def test_zero_length_sequence(klass, rnn_kwargs):
         init_hidden_state = [init_hidden_state]
 
     for idx in range(len(hidden_state)):
-        assert (
-            hidden_state[idx].size() == init_hidden_state[idx].size()
-        ), "Hidden state sizes should be equal"
+        assert hidden_state[idx].size() == init_hidden_state[idx].size(), (
+            "Hidden state sizes should be equal"
+        )
         assert (hidden_state[idx][:, lengths == 0] == 0).all() and (
             hidden_state[idx][:, lengths > 0] != 0
         ).all(), "Hidden state should be zero for zero-length sequences"

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -208,19 +208,19 @@ def _integration(dataloader, tmp_path, loss=None, trainer_kwargs=None, **kwargs)
                     for xi in x.values():
                         check(xi)
                 else:
-                    assert (
-                        pred_len == x.shape[0]
-                    ), "first dimension should be prediction length"
+                    assert pred_len == x.shape[0], (
+                        "first dimension should be prediction length"
+                    )
 
             check(predictions.output)
             if isinstance(predictions.output, torch.Tensor):
-                assert (
-                    predictions.output.ndim == 2
-                ), "shape of predictions should be batch_size x timesteps"
+                assert predictions.output.ndim == 2, (
+                    "shape of predictions should be batch_size x timesteps"
+                )
             else:
-                assert all(
-                    p.ndim == 2 for p in predictions.output
-                ), "shape of predictions should be batch_size x timesteps"
+                assert all(p.ndim == 2 for p in predictions.output), (
+                    "shape of predictions should be batch_size x timesteps"
+                )
             check(predictions.x)
             check(predictions.index)
 

--- a/tests/test_models/test_tft_v2.py
+++ b/tests/test_models/test_tft_v2.py
@@ -336,24 +336,24 @@ def test_model_with_datamodule_integration(
     dm = data_module_for_test
     model_metadata_from_dm = dm.metadata
 
-    assert (
-        model_metadata_from_dm["encoder_cont"] == 6
-    ), f"Actual encoder_cont: {model_metadata_from_dm['encoder_cont']}"
-    assert (
-        model_metadata_from_dm["encoder_cat"] == 0
-    ), f"Actual encoder_cat: {model_metadata_from_dm['encoder_cat']}"
-    assert (
-        model_metadata_from_dm["decoder_cont"] == 2
-    ), f"Actual decoder_cont: {model_metadata_from_dm['decoder_cont']}"
-    assert (
-        model_metadata_from_dm["decoder_cat"] == 0
-    ), f"Actual decoder_cat: {model_metadata_from_dm['decoder_cat']}"
-    assert (
-        model_metadata_from_dm["static_categorical_features"] == 0
-    ), f"Actual static_cat: {model_metadata_from_dm['static_categorical_features']}"
-    assert (
-        model_metadata_from_dm["static_continuous_features"] == 2
-    ), f"Actual static_cont: {model_metadata_from_dm['static_continuous_features']}"
+    assert model_metadata_from_dm["encoder_cont"] == 6, (
+        f"Actual encoder_cont: {model_metadata_from_dm['encoder_cont']}"
+    )
+    assert model_metadata_from_dm["encoder_cat"] == 0, (
+        f"Actual encoder_cat: {model_metadata_from_dm['encoder_cat']}"
+    )
+    assert model_metadata_from_dm["decoder_cont"] == 2, (
+        f"Actual decoder_cont: {model_metadata_from_dm['decoder_cont']}"
+    )
+    assert model_metadata_from_dm["decoder_cat"] == 0, (
+        f"Actual decoder_cat: {model_metadata_from_dm['decoder_cat']}"
+    )
+    assert model_metadata_from_dm["static_categorical_features"] == 0, (
+        f"Actual static_cat: {model_metadata_from_dm['static_categorical_features']}"
+    )
+    assert model_metadata_from_dm["static_continuous_features"] == 2, (
+        f"Actual static_cont: {model_metadata_from_dm['static_continuous_features']}"
+    )
     assert model_metadata_from_dm["target"] == 1
 
     tft_init_args = tft_model_params_fixture_func.copy()

--- a/tests/test_models/test_timexer.py
+++ b/tests/test_models/test_timexer.py
@@ -541,9 +541,9 @@ def test_model_forward_output(dataloaders_with_covariates):
         loss=loss,
     )
 
-    assert (
-        prediction.shape == expected_shape
-    ), f"Expected output shape {expected_shape}, but got {prediction.shape}"
+    assert prediction.shape == expected_shape, (
+        f"Expected output shape {expected_shape}, but got {prediction.shape}"
+    )
 
     quantile_loss = QuantileLoss(quantiles=[0.1, 0.5, 0.9])
     model_quantile = TimeXer.from_dataset(
@@ -594,6 +594,6 @@ def test_model_forward_output(dataloaders_with_covariates):
     for i, (pred_tensor, expected_shape) in enumerate(
         zip(prediction_multi, expected_shapes_multi)
     ):  # noqa: E501
-        assert (
-            pred_tensor.shape == expected_shape
-        ), f"MultiLoss target {i}: Expected {expected_shape}, got {pred_tensor.shape}"  # noqa: E501
+        assert pred_tensor.shape == expected_shape, (
+            f"MultiLoss target {i}: Expected {expected_shape}, got {pred_tensor.shape}"
+        )  # noqa: E501


### PR DESCRIPTION
## Description

This PR improves the error message raised when an invalid `reduction`
argument is passed to `groupby_apply`.

## Changes
- Updated ValueError message to clearly specify the valid options: {'mean', 'sum'}.

This improves debugging clarity without changing functionality.