### PR TITLE
[MNT] Improve error message for invalid reduction argument in groupby_apply

### DIFF
--- a/pytorch_forecasting/utils/_utils.py
+++ b/pytorch_forecasting/utils/_utils.py
@@ -68,7 +68,9 @@ def groupby_apply(
     elif reduction == "sum":
         reduce = torch.sum
     else:
-        raise ValueError(f"Unknown reduction '{reduction}'")
+        raise ValueError(
+            f"Unknown reduction '{reduction}'. Expected one of {{'mean', 'sum'}}."
+        )
     uniques, counts = keys.unique(return_counts=True)
     groups = torch.stack(
         [reduce(item) for item in torch.split_with_sizes(values, tuple(counts))]


### PR DESCRIPTION
#### Reference Issues/PRs

None.

#### What does this implement/fix? Explain your changes.

This PR improves the error message raised when an invalid `reduction`
argument is passed to `groupby_apply`.

Previously, the error message only stated that the reduction was unknown.
This update clarifies the expected valid options: {'mean', 'sum'}.

No functional behavior is changed.

#### What should a reviewer concentrate their feedback on?

- Clarity and wording of the updated error message.
- Whether the expected options are correctly specified.

#### Did you add any tests for the change?

No. This change only improves the error message wording and does not
modify functionality.

#### Any other comments?

This is a minor maintenance improvement to make debugging clearer
for users passing invalid arguments.