### PR TITLE
[ENH] Add TextEmbeddingAligner for merging sparse text embeddings with numerical time-series

### DIFF
--- a/pytorch_forecasting/data/__init__.py
+++ b/pytorch_forecasting/data/__init__.py
@@ -13,6 +13,7 @@ from pytorch_forecasting.data.encoders import (
     TorchNormalizer,
 )
 from pytorch_forecasting.data.samplers import TimeSynchronizedBatchSampler
+from pytorch_forecasting.data.text_embedding_aligner import TextEmbeddingAligner
 from pytorch_forecasting.data.timeseries import TimeSeries, TimeSeriesDataSet
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "EncoderNormalizer",
     "TimeSynchronizedBatchSampler",
     "MultiNormalizer",
+    "TextEmbeddingAligner",
 ]

--- a/pytorch_forecasting/data/text_embedding_aligner.py
+++ b/pytorch_forecasting/data/text_embedding_aligner.py
@@ -1,0 +1,271 @@
+"""Aligner for merging sparse text embeddings with dense numerical time-series.
+
+This module provides :class:`TextEmbeddingAligner`, a scikit-learn–compatible
+transformer that joins pre-computed text embedding vectors onto a numerical
+time-series DataFrame indexed by datetime.  Timestamps without a corresponding
+text embedding are zero-padded to maintain a fixed feature width.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, TransformerMixin
+
+
+class TextEmbeddingAligner(BaseEstimator, TransformerMixin):
+    """Align sparse text embeddings with dense numerical time-series data.
+
+    Given a numerical DataFrame with a datetime index and a dictionary (or
+    DataFrame) mapping timestamps to pre-computed text embedding vectors, this
+    transformer concatenates the embedding onto each numerical row.  When no
+    embedding exists for a given timestamp, a zero-vector of the learned
+    ``embedding_dim`` is used instead.
+
+    The class follows the scikit-learn estimator contract
+    (:class:`~sklearn.base.BaseEstimator` / :class:`~sklearn.base.TransformerMixin`)
+    so it can participate in ``Pipeline`` objects.
+
+    Parameters
+    ----------
+    None – all configuration is inferred from the data during ``fit()``.
+
+    Attributes
+    ----------
+    embedding_dim_ : int
+        Dimensionality of the text embedding vectors, learned during ``fit()``.
+    is_fitted_ : bool
+        Whether the transformer has been fitted.
+
+    Examples
+    --------
+    >>> import pandas as pd, numpy as np
+    >>> idx = pd.date_range("2024-01-01", periods=4, freq="h")
+    >>> numerical_df = pd.DataFrame({"a": [1, 2, 3, 4]}, index=idx)
+    >>> embeddings = {idx[0]: np.array([0.1, 0.2]), idx[2]: np.array([0.3, 0.4])}
+    >>> aligner = TextEmbeddingAligner()
+    >>> aligner.fit(text_embeddings_dict=embeddings)
+    TextEmbeddingAligner()
+    >>> out = aligner.transform(numerical_df)
+    >>> out.shape
+    (4, 3)
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_embeddings(
+        text_embeddings: dict[pd.Timestamp, np.ndarray] | pd.DataFrame,
+    ) -> dict[pd.Timestamp, np.ndarray]:
+        """Normalise embeddings input to a ``{Timestamp: ndarray}`` dict.
+
+        Parameters
+        ----------
+        text_embeddings : Union[dict, pd.DataFrame]
+            Either a dictionary mapping timestamps to 1-D numpy arrays or a
+            DataFrame whose index is datetime and each row is an embedding.
+
+        Returns
+        -------
+        dict[pd.Timestamp, np.ndarray]
+            Canonical mapping from timestamp to embedding vector.
+
+        Raises
+        ------
+        TypeError
+            If *text_embeddings* is neither a dict nor a DataFrame.
+        """
+        if isinstance(text_embeddings, pd.DataFrame):
+            return {ts: row.values for ts, row in text_embeddings.iterrows()}
+        if isinstance(text_embeddings, dict):
+            return text_embeddings
+        raise TypeError(
+            f"text_embeddings must be a dict or pd.DataFrame, "
+            f"got {type(text_embeddings).__name__}"
+        )
+
+    @staticmethod
+    def _infer_embedding_dim(
+        embeddings: dict[pd.Timestamp, np.ndarray],
+    ) -> int:
+        """Return the embedding dimensionality from the first entry.
+
+        Parameters
+        ----------
+        embeddings : dict[pd.Timestamp, np.ndarray]
+            Non-empty mapping of timestamps to embedding vectors.
+
+        Returns
+        -------
+        int
+            Length of the first embedding vector.
+
+        Raises
+        ------
+        ValueError
+            If *embeddings* is empty.
+        """
+        if not embeddings:
+            raise ValueError(
+                "text_embeddings_dict is empty — cannot infer embedding_dim. "
+                "Provide at least one embedding vector."
+            )
+        first_vec = next(iter(embeddings.values()))
+        return int(np.asarray(first_vec).shape[0])
+
+    # ------------------------------------------------------------------
+    # sklearn API
+    # ------------------------------------------------------------------
+
+    def fit(
+        self,
+        X: pd.DataFrame | None = None,
+        y: None = None,
+        *,
+        text_embeddings_dict: (
+            dict[pd.Timestamp, np.ndarray] | pd.DataFrame | None
+        ) = None,
+    ) -> TextEmbeddingAligner:
+        """Learn the embedding dimensionality from supplied text embeddings.
+
+        Parameters
+        ----------
+        X : pd.DataFrame or None, optional
+            Ignored.  Present only for scikit-learn pipeline compatibility.
+        y : None
+            Ignored.
+        text_embeddings_dict : Union[dict, pd.DataFrame]
+            Mapping of timestamps to pre-computed embedding vectors.  At least
+            one entry is required so the embedding dimension can be inferred.
+
+        Returns
+        -------
+        TextEmbeddingAligner
+            Fitted instance (``self``).
+
+        Raises
+        ------
+        ValueError
+            If *text_embeddings_dict* is ``None`` or empty.
+        """
+        if text_embeddings_dict is None:
+            raise ValueError(
+                "text_embeddings_dict must be provided to fit(). "
+                "Pass a dict mapping timestamps to embedding vectors."
+            )
+
+        embeddings = self._resolve_embeddings(text_embeddings_dict)
+        self.embedding_dim_ = self._infer_embedding_dim(embeddings)
+        self.text_embeddings_dict_ = embeddings
+        self.is_fitted_ = True
+        return self
+
+    def transform(
+        self,
+        numerical_df: pd.DataFrame,
+        y: None = None,
+        *,
+        text_embeddings_dict: (
+            dict[pd.Timestamp, np.ndarray] | pd.DataFrame | None
+        ) = None,
+    ) -> np.ndarray:
+        """Concatenate numerical features with aligned text embeddings.
+
+        For each row in *numerical_df*, the corresponding text embedding is
+        looked up by exact timestamp match.  If no embedding exists, a
+        zero-vector of length ``embedding_dim_`` is used.
+
+        Parameters
+        ----------
+        numerical_df : pd.DataFrame
+            Dense numerical time-series with a datetime index.
+        y : None
+            Ignored.
+        text_embeddings_dict : Union[dict, pd.DataFrame], optional
+            Override embedding source.  When ``None`` (default), the embeddings
+            stored during ``fit()`` are used.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape ``(n_timestamps, n_numerical_features + embedding_dim_)``
+            with dtype ``np.float64``.
+
+        Raises
+        ------
+        RuntimeError
+            If the transformer has not been fitted.
+        TypeError
+            If *numerical_df* does not have a datetime index.
+        """
+        if not getattr(self, "is_fitted_", False):
+            raise RuntimeError(
+                "TextEmbeddingAligner has not been fitted yet. "
+                "Call fit() before transform()."
+            )
+
+        if not isinstance(numerical_df.index, pd.DatetimeIndex):
+            raise TypeError(
+                "numerical_df must have a pd.DatetimeIndex. "
+                f"Got index of type {type(numerical_df.index).__name__}."
+            )
+
+        # Resolve which embeddings to use.
+        if text_embeddings_dict is not None:
+            embeddings = self._resolve_embeddings(text_embeddings_dict)
+        else:
+            embeddings = self.text_embeddings_dict_
+
+        embedding_dim = self.embedding_dim_
+
+        numerical_values = numerical_df.values.astype(np.float64)
+        n_rows = len(numerical_df)
+
+        # Pre-allocate the embedding block.
+        embedding_block = np.zeros((n_rows, embedding_dim), dtype=np.float64)
+
+        for i, ts in enumerate(numerical_df.index):
+            vec = embeddings.get(ts)
+            if vec is not None:
+                embedding_block[i] = np.asarray(vec, dtype=np.float64)
+            # else: row already zero-filled
+
+        return np.concatenate([numerical_values, embedding_block], axis=1)
+
+    def fit_transform(
+        self,
+        numerical_df: pd.DataFrame,
+        y: None = None,
+        *,
+        text_embeddings_dict: (
+            dict[pd.Timestamp, np.ndarray] | pd.DataFrame | None
+        ) = None,
+    ) -> np.ndarray:
+        """Fit and transform in a single step.
+
+        Convenience wrapper equivalent to calling ``fit()`` then ``transform()``.
+
+        Parameters
+        ----------
+        numerical_df : pd.DataFrame
+            Dense numerical time-series with a datetime index.
+        y : None
+            Ignored.
+        text_embeddings_dict : Union[dict, pd.DataFrame]
+            Mapping of timestamps to pre-computed embedding vectors.
+
+        Returns
+        -------
+        np.ndarray
+            Concatenated array of shape
+            ``(n_timestamps, n_numerical_features + embedding_dim_)``.
+        """
+        self.fit(text_embeddings_dict=text_embeddings_dict)
+        return self.transform(numerical_df, text_embeddings_dict=text_embeddings_dict)

--- a/tests/test_data/test_text_embedding_aligner.py
+++ b/tests/test_data/test_text_embedding_aligner.py
@@ -1,0 +1,264 @@
+"""Comprehensive tests for :class:`TextEmbeddingAligner`.
+
+Tests cover:
+- Correct concatenation when both numerical and text data exist at a timestamp.
+- Correct zero-padding when text data is missing for a timestamp.
+- Correct handling of different ``embedding_dim`` sizes.
+- Edge cases: all timestamps present, all timestamps missing, not-fitted error.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pytorch_forecasting.data.text_embedding_aligner import TextEmbeddingAligner
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def hourly_index() -> pd.DatetimeIndex:
+    """Four hourly timestamps starting at 2024-01-01 00:00."""
+    return pd.date_range("2024-01-01", periods=4, freq="h")
+
+
+@pytest.fixture()
+def numerical_df(hourly_index: pd.DatetimeIndex) -> pd.DataFrame:
+    """Simple 2-feature numerical DataFrame on an hourly index."""
+    return pd.DataFrame(
+        {"feat_a": [1.0, 2.0, 3.0, 4.0], "feat_b": [10.0, 20.0, 30.0, 40.0]},
+        index=hourly_index,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core alignment tests
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectConcatenation:
+    """When both numerical and text data exist at a timestamp."""
+
+    def test_matching_timestamps_are_concatenated(
+        self, numerical_df: pd.DataFrame, hourly_index: pd.DatetimeIndex
+    ) -> None:
+        """Rows with a matching timestamp should contain the real embedding."""
+        embeddings = {
+            hourly_index[0]: np.array([0.1, 0.2, 0.3]),
+            hourly_index[2]: np.array([0.4, 0.5, 0.6]),
+        }
+
+        aligner = TextEmbeddingAligner()
+        aligner.fit(text_embeddings_dict=embeddings)
+        result = aligner.transform(numerical_df)
+
+        # Row 0: numerical [1, 10] + embedding [0.1, 0.2, 0.3]
+        expected_row_0 = np.array([1.0, 10.0, 0.1, 0.2, 0.3])
+        np.testing.assert_array_almost_equal(result[0], expected_row_0)
+
+        # Row 2: numerical [3, 30] + embedding [0.4, 0.5, 0.6]
+        expected_row_2 = np.array([3.0, 30.0, 0.4, 0.5, 0.6])
+        np.testing.assert_array_almost_equal(result[2], expected_row_2)
+
+
+class TestZeroPaddingMissing:
+    """When text data is missing for a timestamp, embed with zeros."""
+
+    def test_missing_timestamps_are_zero_padded(
+        self, numerical_df: pd.DataFrame, hourly_index: pd.DatetimeIndex
+    ) -> None:
+        """Rows WITHOUT a matching timestamp should have a zero-vector."""
+        embedding_dim = 3
+        embeddings = {
+            hourly_index[0]: np.array([0.1, 0.2, 0.3]),
+        }
+
+        aligner = TextEmbeddingAligner()
+        aligner.fit(text_embeddings_dict=embeddings)
+        result = aligner.transform(numerical_df)
+
+        # Rows 1, 2, 3 have no embedding → zeros appended.
+        for row_idx in [1, 2, 3]:
+            np.testing.assert_array_equal(
+                result[row_idx, 2:],
+                np.zeros(embedding_dim),
+            )
+
+    def test_all_timestamps_missing(
+        self, numerical_df: pd.DataFrame, hourly_index: pd.DatetimeIndex
+    ) -> None:
+        """If NO timestamp matches, every embedding slot should be zeros."""
+        embedding_dim = 4
+        # Use a timestamp that is NOT in the hourly index.
+        unrelated_ts = pd.Timestamp("1999-12-31")
+        embeddings = {unrelated_ts: np.ones(embedding_dim)}
+
+        aligner = TextEmbeddingAligner()
+        aligner.fit(text_embeddings_dict=embeddings)
+        result = aligner.transform(numerical_df)
+
+        # All embedding columns should be zero.
+        np.testing.assert_array_equal(
+            result[:, 2:],
+            np.zeros((len(numerical_df), embedding_dim)),
+        )
+
+
+class TestAllTimestampsPresent:
+    """When every numerical timestamp has a corresponding embedding."""
+
+    def test_no_zero_padding_needed(
+        self, numerical_df: pd.DataFrame, hourly_index: pd.DatetimeIndex
+    ) -> None:
+        embedding_dim = 2
+        embeddings = {
+            ts: np.full(embedding_dim, i + 1.0) for i, ts in enumerate(hourly_index)
+        }
+
+        aligner = TextEmbeddingAligner()
+        aligner.fit(text_embeddings_dict=embeddings)
+        result = aligner.transform(numerical_df)
+
+        for i in range(len(numerical_df)):
+            np.testing.assert_array_almost_equal(
+                result[i, 2:],
+                np.full(embedding_dim, i + 1.0),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Different embedding dimensions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("embedding_dim", [8, 64, 128, 768])
+def test_different_embedding_dims(
+    numerical_df: pd.DataFrame,
+    hourly_index: pd.DatetimeIndex,
+    embedding_dim: int,
+) -> None:
+    """Output shape should adapt correctly to varying embedding dimensions."""
+    embeddings = {hourly_index[0]: np.random.randn(embedding_dim)}
+
+    aligner = TextEmbeddingAligner()
+    aligner.fit(text_embeddings_dict=embeddings)
+    result = aligner.transform(numerical_df)
+
+    n_numerical_features = numerical_df.shape[1]
+    assert result.shape == (len(numerical_df), n_numerical_features + embedding_dim)
+
+
+# ---------------------------------------------------------------------------
+# Output shape
+# ---------------------------------------------------------------------------
+
+
+def test_output_shape(
+    numerical_df: pd.DataFrame, hourly_index: pd.DatetimeIndex
+) -> None:
+    """General output shape contract: (n_rows, n_features + embedding_dim)."""
+    embedding_dim = 5
+    embeddings = {hourly_index[1]: np.ones(embedding_dim)}
+
+    aligner = TextEmbeddingAligner()
+    aligner.fit(text_embeddings_dict=embeddings)
+    result = aligner.transform(numerical_df)
+
+    assert result.shape == (4, 2 + embedding_dim)
+    assert result.dtype == np.float64
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Guard-rail tests for bad usage patterns."""
+
+    def test_not_fitted_raises(self, numerical_df: pd.DataFrame) -> None:
+        """Calling transform() before fit() must raise RuntimeError."""
+        aligner = TextEmbeddingAligner()
+        with pytest.raises(RuntimeError, match="has not been fitted"):
+            aligner.transform(numerical_df)
+
+    def test_fit_with_no_embeddings_raises(self) -> None:
+        """fit() without text_embeddings_dict must raise ValueError."""
+        aligner = TextEmbeddingAligner()
+        with pytest.raises(ValueError, match="text_embeddings_dict must be provided"):
+            aligner.fit()
+
+    def test_fit_with_empty_dict_raises(self) -> None:
+        """fit() with an empty dict must raise ValueError."""
+        aligner = TextEmbeddingAligner()
+        with pytest.raises(ValueError, match="empty"):
+            aligner.fit(text_embeddings_dict={})
+
+    def test_non_datetime_index_raises(self, hourly_index: pd.DatetimeIndex) -> None:
+        """transform() with a non-datetime index must raise TypeError."""
+        df = pd.DataFrame({"a": [1, 2]}, index=[0, 1])
+        embeddings = {hourly_index[0]: np.array([1.0])}
+
+        aligner = TextEmbeddingAligner()
+        aligner.fit(text_embeddings_dict=embeddings)
+
+        with pytest.raises(TypeError, match="DatetimeIndex"):
+            aligner.transform(df)
+
+    def test_invalid_embeddings_type_raises(self) -> None:
+        """Passing a list instead of dict/DataFrame must raise TypeError."""
+        aligner = TextEmbeddingAligner()
+        with pytest.raises(TypeError, match="dict or pd.DataFrame"):
+            aligner.fit(text_embeddings_dict=[[1, 2, 3]])
+
+
+# ---------------------------------------------------------------------------
+# DataFrame-based embeddings
+# ---------------------------------------------------------------------------
+
+
+def test_dataframe_embeddings(
+    numerical_df: pd.DataFrame, hourly_index: pd.DatetimeIndex
+) -> None:
+    """Embeddings supplied as a DataFrame should work identically to a dict."""
+    embedding_dim = 3
+    emb_df = pd.DataFrame(
+        [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+        index=[hourly_index[0], hourly_index[2]],
+        columns=["e0", "e1", "e2"],
+    )
+
+    aligner = TextEmbeddingAligner()
+    aligner.fit(text_embeddings_dict=emb_df)
+    result = aligner.transform(numerical_df)
+
+    expected_row_0 = np.array([1.0, 10.0, 0.1, 0.2, 0.3])
+    np.testing.assert_array_almost_equal(result[0], expected_row_0)
+
+    # Missing row 1 → zeros
+    np.testing.assert_array_equal(result[1, 2:], np.zeros(embedding_dim))
+
+
+# ---------------------------------------------------------------------------
+# fit_transform shortcut
+# ---------------------------------------------------------------------------
+
+
+def test_fit_transform(
+    numerical_df: pd.DataFrame, hourly_index: pd.DatetimeIndex
+) -> None:
+    """fit_transform should produce identical results to fit() + transform()."""
+    embeddings = {hourly_index[0]: np.array([1.0, 2.0])}
+
+    aligner_a = TextEmbeddingAligner()
+    aligner_a.fit(text_embeddings_dict=embeddings)
+    result_a = aligner_a.transform(numerical_df)
+
+    aligner_b = TextEmbeddingAligner()
+    result_b = aligner_b.fit_transform(numerical_df, text_embeddings_dict=embeddings)
+
+    np.testing.assert_array_equal(result_a, result_b)


### PR DESCRIPTION


#### Reference Issues/PRs

#2091


#### What does this implement/fix? Explain your changes.

Adds a new [TextEmbeddingAligner](cci:2://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/text_embedding_aligner.py:17:0-271:86) class in [pytorch_forecasting/data/text_embedding_aligner.py](cci:7://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/text_embedding_aligner.py:0:0-0:0) that aligns sparse pre-computed text embedding vectors with dense numerical time-series data.

**Key functionality:**
- Accepts a numerical `pd.DataFrame` (with datetime index) and a dictionary (or DataFrame) of text embeddings mapped to timestamps.
- For each numerical timestamp, performs an exact-match lookup for the corresponding text embedding.
- If no text embedding exists for a timestamp, zero-pads with a `0.0` vector of the correct [embedding_dim](cci:1://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/text_embedding_aligner.py:93:4-120:50).
- Returns a concatenated `np.ndarray` of shape [(n_timestamps, n_numerical_features + embedding_dim)](cci:1://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/encoders.py:884:4-914:19).
- Follows scikit-learn `BaseEstimator` / `TransformerMixin` patterns, consistent with existing encoders like [NaNLabelEncoder](cci:2://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/encoders.py:266:0-491:44) and [TorchNormalizer](cci:2://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/encoders.py:494:0-817:39).

**Files changed:**
- `[NEW]` [pytorch_forecasting/data/text_embedding_aligner.py](cci:7://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/text_embedding_aligner.py:0:0-0:0) — the transformer class
- `[NEW]` [tests/test_data/test_text_embedding_aligner.py](cci:7://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/tests/test_data/test_text_embedding_aligner.py:0:0-0:0) — comprehensive pytest suite
- `[MOD]` [pytorch_forecasting/data/__init__.py](cci:7://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/__init__.py:0:0-0:0) — registered in public API

#### What should a reviewer concentrate their feedback on?

- The alignment logic in [transform()](cci:1://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/encoders.py:1214:4-1246:87) — currently V1 with exact timestamp matching only (no forward-fill).
- Whether the sklearn `BaseEstimator`/`TransformerMixin` inheritance is appropriate, or if a different base class from the project is preferred.
- Docstring style and consistency with the rest of the codebase.

#### Did you add any tests for the change?

Yes — 12 pytest test cases in [tests/test_data/test_text_embedding_aligner.py](cci:7://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/tests/test_data/test_text_embedding_aligner.py:0:0-0:0) covering:

- [x] Correct concatenation when both data types exist at a timestamp
- [x] Correct zero-padding when text data is missing
- [x] Parametrized test for different [embedding_dim](cci:1://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/text_embedding_aligner.py:93:4-120:50) sizes (8, 64, 128, 768)
- [x] Edge case: all timestamps missing (full zero-pad)
- [x] Edge case: all timestamps present (no zero-pad)
- [x] Error handling: not-fitted, empty dict, no args, non-datetime index, invalid type
- [x] DataFrame-based embeddings input
- [x] [fit_transform()](cci:1://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/encoders.py:288:4-305:32) equivalence with [fit()](cci:1://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/encoders.py:884:4-914:19) + [transform()](cci:1://file:///c:/Users/singh/Documents/GitHub/pytorch-forecasting/pytorch_forecasting/data/encoders.py:1214:4-1246:87)

#### Any other comments?

This is a V1 implementation with exact timestamp matching. Future enhancements could include forward-fill / time-binning alignment strategies and optional torch tensor output.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. → **[ENH] Add TextEmbeddingAligner for merging sparse text embeddings with numerical time-series**
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.

