### PR TITLE
feat: port full TFT architecture to v2 API 

### DIFF
--- a/pytorch_forecasting/models/temporal_fusion_transformer/_tft_v2.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/_tft_v2.py
@@ -273,7 +273,7 @@ class TFT(BaseModel):
 
         # 2. Encoder Variable Selection
         if self.encoder_input_dim > 0:
-            self.encoder_variable_selection = VariableSelectionNetwork(
+            self.encoder_var_selection = VariableSelectionNetwork(
                 input_sizes=enc_input_sizes,
                 hidden_size=self.hidden_size,
                 input_embedding_flags={
@@ -285,11 +285,11 @@ class TFT(BaseModel):
                 single_variable_grns=self.shared_single_variable_grns,
             )
         else:
-            self.encoder_variable_selection = None
+            self.encoder_var_selection = None
 
         # 3. Decoder Variable Selection
         if self.decoder_input_dim > 0:
-            self.decoder_variable_selection = VariableSelectionNetwork(
+            self.decoder_var_selection = VariableSelectionNetwork(
                 input_sizes=dec_input_sizes,
                 hidden_size=self.hidden_size,
                 input_embedding_flags={
@@ -301,7 +301,7 @@ class TFT(BaseModel):
                 single_variable_grns=self.shared_single_variable_grns,
             )
         else:
-            self.decoder_variable_selection = None
+            self.decoder_var_selection = None
 
         # 4. Static Context GRNs
         # (a) context for variable selection
@@ -504,7 +504,7 @@ class TFT(BaseModel):
         static_context_enrichment = self.static_context_enrichment(static_embedding)
 
         # 3. Encoder Variable Selection
-        if self.encoder_variable_selection is not None and self.encoder_input_dim > 0:
+        if self.encoder_var_selection is not None and self.encoder_input_dim > 0:
             encoder_dict = self._split_to_variable_dict(
                 encoder_cont,
                 encoder_cat,
@@ -512,7 +512,7 @@ class TFT(BaseModel):
                 [f"enc_cat_{i}" for i in range(self.encoder_cat)],
             )
             embeddings_varying_encoder, encoder_sparse_weights = (
-                self.encoder_variable_selection(
+                self.encoder_var_selection(
                     encoder_dict,
                     static_context_variable_selection[:, : self.max_encoder_length],
                 )
@@ -527,7 +527,7 @@ class TFT(BaseModel):
             )
 
         # 4. Decoder Variable Selection
-        if self.decoder_variable_selection is not None and self.decoder_input_dim > 0:
+        if self.decoder_var_selection is not None and self.decoder_input_dim > 0:
             decoder_dict = self._split_to_variable_dict(
                 decoder_cont,
                 decoder_cat,
@@ -535,7 +535,7 @@ class TFT(BaseModel):
                 [f"dec_cat_{i}" for i in range(self.decoder_cat)],
             )
             embeddings_varying_decoder, decoder_sparse_weights = (
-                self.decoder_variable_selection(
+                self.decoder_var_selection(
                     decoder_dict,
                     static_context_variable_selection[:, self.max_encoder_length :],
                 )

--- a/tests/test_models/test_tft_v2.py
+++ b/tests/test_models/test_tft_v2.py
@@ -146,8 +146,8 @@ def test_basic_initialization(tft_model_params_fixture_func):
         + metadata["static_continuous_features"]
     )
     assert isinstance(model.lstm_encoder, nn.LSTM)
-    assert model.lstm_encoder.input_size == max(1, model.encoder_input_dim)
-    assert isinstance(model.self_attention, nn.MultiheadAttention)
+    assert model.lstm_encoder.input_size == model.hidden_size
+    assert isinstance(model.multihead_attn, nn.Module)
     if hasattr(model, "hparams") and model.hparams:
         assert model.hparams.get("hidden_size") == HIDDEN_SIZE_TEST
     assert model.output_size == OUTPUT_SIZE_TEST
@@ -167,10 +167,10 @@ def test_initialization_no_time_varying_features(tft_model_params_fixture_func):
     model = TFT(**tft_model_params_fixture_func, metadata=metadata)
     assert model.encoder_input_dim == 0
     assert model.encoder_var_selection is None
-    assert model.lstm_encoder.input_size == 1
+    assert model.lstm_encoder.input_size == HIDDEN_SIZE_TEST
     assert model.decoder_input_dim == 0
     assert model.decoder_var_selection is None
-    assert model.lstm_decoder.input_size == 1
+    assert model.lstm_decoder.input_size == HIDDEN_SIZE_TEST
 
 
 def test_initialization_no_static_features(tft_model_params_fixture_func):
@@ -185,7 +185,7 @@ def test_initialization_no_static_features(tft_model_params_fixture_func):
     )
     model = TFT(**tft_model_params_fixture_func, metadata=metadata)
     assert model.static_input_dim == 0
-    assert model.static_context_linear is None
+    assert model.static_variable_selection is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2103 


#### What does this implement/fix? Explain your changes.

The current _tft_v2.py successfully interfaces with the v2 data pipeline, but it is currently just an experimental skeleton using basic nn.Linear layers and standard nn.MultiheadAttention. This PR upgrades the v2 skeleton to the actual Temporal Fusion Transformer paper architecture.
1. Replaced standard attention with InterpretableMultiHeadAttention.
2. Reintegrated the VariableSelectionNetwork (VSN) for static, encoder, and decoder variables.
3. Restored the four static context GatedResidualNetworks to properly prime the LSTM hidden/cell states and enrich the timeline.
Handling v2 Pipeline Disconnects:


Categorical Embeddings Workaround: The v2 datamodule metadata currently does not expose the vocabulary sizes (cardinality) of categorical variables, meaning we cannot initialize proper nn.Embedding layers. To unblock the VSN forward pass, I temporarily treated categorical inputs as continuous, using nn.Linear prescalers and setting input_embedding_flags=False. Note: I will be opening a separate issue to track adding vocabulary cardinality to the v2 data module metadata.

#### What should a reviewer concentrate their feedback on?

1. The mapping of flat v2 tensor counts to VSN dictionary inputs using synthetic names and custom prescalers in the __init__.
2. The tensor slicing and dictionary generation inside the forward pass.
3. The temporary nn.Linear workaround for categorical embeddings.

#### Did you add any tests for the change?

I didnt create and but I verified the architecture and forward pass by successfully training the model locally using the @ptf_V2_example.ipynb notebook (loss successfully decreased over epochs).

#### Any other comments?

This is an initial architecture port focused entirely on getting the complex forward pass mathematically accurate and running with the v2 data layer. Interpretation logging, attention plotting, and visualization (from v1) are currently omitted to keep this PR focused and will be addressed in a follow-up PR. And also the bug in the datapipeline (not passing the vocab size for categorical value)

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
   Modified existing unit tests (`test_tft_v2.py`): The original unit tests were written for the temporary v2 skeleton and were asserting the existence of placeholder layers. I updated the tests to reflect the actual paper architecture:
    Variable mismatches: Updated test assertions to look for the correct components (e.g., replacing `model.static_context_linear` with `model.static_variable_selection`, and `model.self_attention` with `model.multihead_attn`).
    LSTM Input Size: Corrected the test expectation for `lstm_encoder.input_size`. The old skeleton fed raw inputs into the LSTM, but the proper architecture projects all inputs through the `VariableSelectionNetwork` first. The test now correctly asserts `HIDDEN_SIZE_TEST` instead of `1`.

    I also verified the full forward pass and training loop locally by successfully running the `ptf_V2_example.ipynb` notebook end-to-end.

- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`
