### PR TITLE
[BUG] Fix RuntimeError in predict(return_y=True) with unequal batch sizes

### DIFF
--- a/tests/test_models/test_predict_return_y.py
+++ b/tests/test_models/test_predict_return_y.py
@@ -1,0 +1,130 @@
+"""Tests for predict with return_y=True and unequal batch sizes.
+
+Regression tests for the bug where ``model.predict(dataloader, return_y=True)``
+raises ``RuntimeError: Sizes of tensors must match except in dimension 1``
+when the last batch is smaller than the rest, or when decoder lengths vary
+across batches.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from pytorch_forecasting import Baseline, TimeSeriesDataSet
+
+
+@pytest.fixture(scope="module")
+def data():
+    """Simple synthetic dataset for testing predict with return_y."""
+    torch.manual_seed(23)
+    np.random.seed(23)
+    return pd.DataFrame(
+        dict(
+            value=np.random.rand(30) - 0.5,
+            group=np.repeat(np.arange(3), 10),
+            time_idx=np.tile(np.arange(10), 3),
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def dataset_fixed_length(data):
+    """Dataset with fixed prediction length (min == max)."""
+    return TimeSeriesDataSet(
+        data,
+        group_ids=["group"],
+        target="value",
+        time_idx="time_idx",
+        max_encoder_length=2,
+        max_prediction_length=1,
+        time_varying_unknown_reals=["value"],
+    )
+
+
+@pytest.fixture(scope="module")
+def dataset_variable_length(data):
+    """Dataset with variable prediction length (min < max).
+
+    This triggers per-batch padding via ``rnn.pad_sequence`` in the collate
+    function, which can lead to different ``dim=1`` across batches.
+    """
+    return TimeSeriesDataSet(
+        data,
+        group_ids=["group"],
+        target="value",
+        time_idx="time_idx",
+        max_encoder_length=4,
+        min_encoder_length=2,
+        max_prediction_length=3,
+        min_prediction_length=1,
+        time_varying_unknown_reals=["value"],
+    )
+
+
+def test_predict_return_y_unequal_last_batch(dataset_fixed_length):
+    """Test predict(return_y=True) when last batch is smaller than batch_size."""
+    n_samples = len(dataset_fixed_length)
+    # pick a batch_size that does not evenly divide the dataset
+    batch_size = max(2, n_samples // 3 + 1)
+    dataloader = dataset_fixed_length.to_dataloader(
+        train=False, batch_size=batch_size, num_workers=0
+    )
+
+    result = Baseline().predict(dataloader, return_y=True)
+
+    assert result.y is not None
+    y, weight = result.y
+    assert isinstance(y, torch.Tensor)
+    assert y.shape[0] == n_samples
+
+
+def test_predict_return_y_variable_decoder_length(dataset_variable_length):
+    """Test predict(return_y=True) with variable decoder lengths across batches.
+
+    When ``min_prediction_length < max_prediction_length``, different batches
+    may have different maximum decoder lengths.  The collate function pads
+    targets per-batch via ``rnn.pad_sequence``, so the ``dim=1`` of the target
+    tensor can differ across batches.  Previously this caused a RuntimeError
+    in ``concat_sequences`` which used bare ``torch.cat(dim=0)``.
+    """
+    n_samples = len(dataset_variable_length)
+    batch_size = max(2, n_samples // 3 + 1)
+    dataloader = dataset_variable_length.to_dataloader(
+        train=False, batch_size=batch_size, num_workers=0
+    )
+
+    result = Baseline().predict(dataloader, return_y=True)
+
+    assert result.y is not None
+    y, weight = result.y
+    assert isinstance(y, torch.Tensor)
+    assert y.shape[0] == n_samples
+
+
+def test_predict_return_y_batch_size_one(dataset_fixed_length):
+    """Test predict(return_y=True) with batch_size=1 (every batch is size 1)."""
+    dataloader = dataset_fixed_length.to_dataloader(
+        train=False, batch_size=1, num_workers=0
+    )
+
+    result = Baseline().predict(dataloader, return_y=True)
+
+    assert result.y is not None
+    y, weight = result.y
+    assert isinstance(y, torch.Tensor)
+    assert y.shape[0] == len(dataset_fixed_length)
+
+
+def test_predict_return_y_false_still_works(dataset_fixed_length):
+    """Ensure return_y=False still works after the fix (no regression)."""
+    n_samples = len(dataset_fixed_length)
+    batch_size = max(2, n_samples // 3 + 1)
+    dataloader = dataset_fixed_length.to_dataloader(
+        train=False, batch_size=batch_size, num_workers=0
+    )
+
+    result = Baseline().predict(dataloader, return_y=False)
+
+    # When return_y=False the result is a plain tensor, not a Prediction tuple
+    assert isinstance(result, torch.Tensor)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1810
Fixes #1752
Relates to #1320, #1509

#### What does this implement/fix? Explain your changes.

`model.predict(dataloader, return_y=True)` throws a `RuntimeError` when batches have different sizes or different decoder lengths across batches.

**Root cause:** In `PredictCallback.on_predict_epoch_end()`, the `return_y` path uses `concat_sequences()` to join per-batch targets. This function calls `torch.cat(dim=0)` directly, which requires all non-concatenation dimensions to match. But `TimeSeriesDataSet._collate_fn` pads targets per-batch using `rnn.pad_sequence`, so when `min_prediction_length < max_prediction_length`, batches end up with different `dim=1` sizes (e.g. `(64, 12)` vs `(44, 8)`). `torch.cat` then fails.

The prediction output side doesn't have this problem — it already uses `_torch_cat_na()`, which NaN-pads `dim=1` to the max before concatenating. The `y`/`weight` path just lacked the same handling.

**Fix:** Replaced `concat_sequences` with `_torch_cat_na` in the `return_y` block. Added multi-target support (list/tuple of tensors) following the same pattern used for multi-target prediction outputs at lines 366–369. Applied the same defensive fix to the v2 callback.

This also addresses why previous fix attempts (#1782, #1783, #1786) broke other models — they swapped the function but didn't account for multi-target scenarios.

**Files changed:**
- `pytorch_forecasting/models/base/_base_model.py` — replaced `concat_sequences` with `_torch_cat_na` for `y` and `weight` in v1 `PredictCallback.on_predict_epoch_end()`, with multi-target handling. Removed now-unused `concat_sequences` import.
- `pytorch_forecasting/callbacks/predict.py` — added a local `_torch_cat_na()` helper and replaced bare `torch.cat` calls in v2 `PredictCallback.on_predict_epoch_end()`.
- `tests/test_models/test_predict_return_y.py` — new regression test file.

#### What should a reviewer concentrate their feedback on?

- The `concat_sequences` → `_torch_cat_na` swap in v1 `PredictCallback.on_predict_epoch_end()` (this is the core fix)
- Multi-target handling for `y` and `weight` (list/tuple branch)
- `_torch_cat_na` is duplicated in `callbacks/predict.py` to avoid circular imports — open to moving it to a shared utility if preferred

#### Did you add any tests for the change?

Yes — 4 tests in `tests/test_models/test_predict_return_y.py`:

- `test_predict_return_y_unequal_last_batch` — batch_size doesn't divide evenly, fixed decoder length
- `test_predict_return_y_variable_decoder_length` — `min_prediction_length < max_prediction_length` across batches (the actual trigger, matches #1752 scenario)
- `test_predict_return_y_batch_size_one` — edge case with batch_size=1
- `test_predict_return_y_false_still_works` — confirms `return_y=False` is unaffected

All tests use self-contained synthetic data, no external files or fixtures needed.

Also verified against #1752's exact reproduction script (100 series, `min_prediction_length=1`, `max_prediction_length=12`, `batch_size=64`) — runs end-to-end including SMAPE calculation.

#### Any other comments?

`concat_sequences` itself was left unchanged — it's a general-purpose utility that also handles `PackedSequence` and is used recursively for nested structures. Modifying it would risk side effects elsewhere. The fix is scoped to the callback, which is where per-batch results get assembled and where the shape mismatch actually matters.

#### PR checklist

- [x] The PR title starts with [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.