### PR TITLE
[DOC] migrate baseline.py docstrings to numpydocstyle 

### DIFF
--- a/pytorch_forecasting/models/baseline.py
+++ b/pytorch_forecasting/models/baseline.py
@@ -35,11 +35,15 @@ class Baseline(BaseModel):
         """
         Network forward pass.
 
-        Args:
-            x (Dict[str, torch.Tensor]): network input
+        Parameters
+        ----------
+        x : dict of {str : torch.Tensor}
+            network input
 
-        Returns:
-            Dict[str, torch.Tensor]: network outputs
+        Returns
+        -------
+        dict of {str : torch.Tensor}
+            network outputs
         """
         if isinstance(x["encoder_target"], tuple | list):  # multiple targets
             prediction = [

--- a/pytorch_forecasting/models/baseline.py
+++ b/pytorch_forecasting/models/baseline.py
@@ -37,12 +37,12 @@ class Baseline(BaseModel):
 
         Parameters
         ----------
-        x : dict of {str : torch.Tensor}
+        x : Dict[str, torch.Tensor]
             network input
 
         Returns
         -------
-        dict of {str : torch.Tensor}
+        Dict[str, torch.Tensor]
             network outputs
         """
         if isinstance(x["encoder_target"], tuple | list):  # multiple targets


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #2066

#### What does this implement/fix? Explain your changes.

Migrates the docstrings in [pytorch_forecasting/models/baseline.py](cci:7://file:///home/amruth/amruth/projects/pytorch-forecasting/pytorch_forecasting/models/baseline.py:0:0-0:0) from Google style  to NumPy docstring style , as part of the repo-wide numpydocstyle migration tracked in #2066.

#### Did you add any tests for the change?

No — this is a documentation-only change with no functional code modifications.

#### Any other comments?

None.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.
