### PR TITLE
[BUG] add label encoders to TimeSeries D1 layer to fix string categorical crash

### DIFF
--- a/pytorch_forecasting/data/timeseries/_timeseries_v2.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries_v2.py
@@ -89,6 +89,7 @@ class TimeSeries(Dataset):
         known: list[str | list[str]] | None = None,
         unknown: list[str | list[str]] | None = None,
         static: list[str | list[str]] | None = None,
+        label_encoders: dict | None = None,
     ):
         self.data = data
         self.data_future = data_future
@@ -139,6 +140,9 @@ class TimeSeries(Dataset):
 
         self._prepare_metadata()
 
+        # fit label encoders for categorical columns
+        self.label_encoders = self._fit_label_encoders(label_encoders)
+
         # overwrite __init__ params for upwards compatibility with AS PRs
         # todo: should we avoid this and ensure classes are dataclass-like?
         self.group = self._group
@@ -148,6 +152,48 @@ class TimeSeries(Dataset):
         self.known = self._known
         self.unknown = self._unknown
         self.static = self._static
+
+    def _fit_label_encoders(self, label_encoders: dict | None) -> dict:
+        """Fit label encoders for categorical columns.
+
+        Fits a NaNLabelEncoder for each column in ``cat``. Also auto-detects
+        object-dtype columns not listed in ``cat`` and encodes them with a warning.
+        Pre-fitted encoders can be passed in via ``label_encoders`` to skip refitting.
+        """
+        from pytorch_forecasting.data.encoders import NaNLabelEncoder
+
+        encoders = dict(label_encoders) if label_encoders else {}
+
+        # columns explicitly declared as categorical
+        declared_cat = set(self._cat)
+
+        # also auto-detect non-numeric columns not declared in cat
+        all_check_cols = [
+            col for col in self.feature_cols + self._static if col in self.data.columns
+        ]
+        for col in all_check_cols:
+            if col not in declared_cat and pd.api.types.is_string_dtype(self.data[col]):
+                warn(
+                    f"Column '{col}' has object dtype but is not listed in `cat`. "
+                    "It will be label-encoded automatically. "
+                    "Declare it in `cat` to suppress this warning.",
+                    UserWarning,
+                    stacklevel=4,
+                )
+                declared_cat.add(col)
+
+        for col in declared_cat:
+            if col not in self.data.columns:
+                continue
+            if col not in encoders:
+                enc = NaNLabelEncoder(add_nan=True)
+                enc.fit(self.data[col])
+                encoders[col] = enc
+            elif not hasattr(encoders[col], "classes_"):
+                # provided but not yet fitted
+                encoders[col].fit(self.data[col])
+
+        return encoders
 
     def _prepare_metadata(self):
         """Prepare metadata for the dataset.
@@ -239,7 +285,23 @@ class TimeSeries(Dataset):
         # PyTorch wants writeable arrays
         data_vals = data[time].to_numpy(copy=True)
         data_tgt_vals = data[_target].to_numpy(copy=True)
-        data_feat_vals = data[feature_cols].to_numpy(copy=True)
+
+        # apply label encoders to categorical feature columns before tensor conversion
+        data_feat = data[feature_cols].copy()
+        for col in feature_cols:
+            if col in self.label_encoders:
+                data_feat[col] = self.label_encoders[col].transform(data_feat[col])
+        # convert column-by-column to handle mixed types safely
+        data_feat_vals = (
+            np.column_stack(
+                [
+                    data_feat[col].to_numpy(dtype=float, copy=True)
+                    for col in feature_cols
+                ]
+            )
+            if feature_cols
+            else np.empty((len(data), 0), dtype=float)
+        )
 
         result = {
             "t": data_vals,

--- a/tests/test_data/test_d1.py
+++ b/tests/test_data/test_d1.py
@@ -377,3 +377,148 @@ def test_metadata_structure(sample_data):
 
     assert metadata["col_known"]["feature1"] == "K"
     assert metadata["col_known"]["feature2"] == "U"
+
+
+# --- label encoder tests ---
+
+
+@pytest.fixture
+def cat_data():
+    """Create time series data with string categorical features."""
+    data = pd.DataFrame(
+        {
+            "time": list(range(10)) * 2,
+            "group": ["A"] * 10 + ["B"] * 10,
+            "target": np.random.randn(20),
+            "cat_color": ["red", "blue", "green", "red", "blue"] * 4,
+            "cat_size": ["small", "medium", "large", "small", "medium"] * 4,
+            "num_feat": np.random.randn(20),
+        }
+    )
+    return data
+
+
+def test_label_encoders_fitted_on_init(cat_data):
+    """Label encoders should be auto-fitted for all cat columns during __init__."""
+    ts = TimeSeries(
+        data=cat_data,
+        time="time",
+        target="target",
+        group=["group"],
+        cat=["cat_color", "cat_size"],
+        num=["num_feat"],
+    )
+
+    assert hasattr(ts, "label_encoders")
+    assert "cat_color" in ts.label_encoders
+    assert "cat_size" in ts.label_encoders
+    assert hasattr(ts.label_encoders["cat_color"], "classes_")
+    assert hasattr(ts.label_encoders["cat_size"], "classes_")
+
+
+def test_label_encoders_cover_all_cat_values(cat_data):
+    """Encoder classes_ should contain all unique values from the column."""
+    ts = TimeSeries(
+        data=cat_data,
+        time="time",
+        target="target",
+        group=["group"],
+        cat=["cat_color"],
+        num=["num_feat"],
+    )
+
+    enc = ts.label_encoders["cat_color"]
+    for val in cat_data["cat_color"].unique():
+        assert val in enc.classes_, f"'{val}' missing from encoder classes_"
+
+
+def test_getitem_cat_columns_are_numeric(cat_data):
+    """After encoding, x tensor must be fully numeric (no strings)."""
+    ts = TimeSeries(
+        data=cat_data,
+        time="time",
+        target="target",
+        group=["group"],
+        cat=["cat_color", "cat_size"],
+        num=["num_feat"],
+    )
+
+    result = ts[0]
+    assert torch.is_tensor(result["x"]), "x should be a tensor"
+    assert result["x"].dtype in (
+        torch.float32,
+        torch.float64,
+    ), "x should be float after encoding"
+    # no NaNs from failed conversion
+    assert not torch.isnan(result["x"]).all()
+
+
+def test_getitem_encoded_values_are_integers(cat_data):
+    """Encoded categorical columns should contain integer-like values."""
+    ts = TimeSeries(
+        data=cat_data,
+        time="time",
+        target="target",
+        group=["group"],
+        cat=["cat_color"],
+        num=["num_feat"],
+    )
+
+    cat_col_idx = ts.feature_cols.index("cat_color")
+    result = ts[0]
+    encoded_vals = result["x"][:, cat_col_idx]
+    # all values should be whole numbers (integers stored as float)
+    assert torch.all(
+        encoded_vals == encoded_vals.floor()
+    ), "Encoded categorical values should be integer-valued"
+
+
+def test_no_label_encoders_for_numeric_only(sample_data):
+    """No label encoders should be created when there are no cat columns."""
+    ts = TimeSeries(
+        data=sample_data,
+        time="timestamp",
+        target="target_value",
+        num=["feature1", "feature2", "feature3"],
+        cat=[],
+    )
+
+    assert ts.label_encoders == {}
+
+
+def test_custom_label_encoder_is_used(cat_data):
+    """A pre-fitted encoder passed via label_encoders should be used as-is."""
+    from pytorch_forecasting.data.encoders import NaNLabelEncoder
+
+    custom_enc = NaNLabelEncoder(add_nan=False)
+    custom_enc.fit(cat_data["cat_color"])
+
+    ts = TimeSeries(
+        data=cat_data,
+        time="time",
+        target="target",
+        group=["group"],
+        cat=["cat_color"],
+        num=["num_feat"],
+        label_encoders={"cat_color": custom_enc},
+    )
+
+    assert ts.label_encoders["cat_color"] is custom_enc
+
+
+def test_label_encoder_inverse_transform(cat_data):
+    """Inverse transform should recover original category values."""
+    ts = TimeSeries(
+        data=cat_data,
+        time="time",
+        target="target",
+        group=["group"],
+        cat=["cat_color"],
+        num=["num_feat"],
+    )
+
+    enc = ts.label_encoders["cat_color"]
+    original = cat_data["cat_color"].iloc[:5].values
+    encoded = enc.transform(original)
+    decoded = enc.inverse_transform(encoded)
+    np.testing.assert_array_equal(decoded, original)


### PR DESCRIPTION

<!--
Welcome to pytorch-forecasting, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes part of #1974 (Add label_encoders to D1 Layer)

#### What does this implement/fix? Explain your changes.
TimeSeries.__getitem__ was calling torch.tensor() directly on raw feature values. If any column declared in cat had string/object dtype, this would crash with a TypeError since PyTorch can't convert string arrays to tensors.

This adds a _fit_label_encoders() method that fits a NaNLabelEncoder for each column listed in cat during __init__. It also auto-detects any object-dtype columns not declared in cat and encodes them with a UserWarning, so things don't silently break. The encoders are applied in __getitem__ before building the feature tensor, converting string categories to integer codes first.

A label_encoders parameter was also added to __init__ so callers can pass in pre-fitted encoders if needed (e.g. to reuse encoders fitted on training data at inference time).


#### What should a reviewer concentrate their feedback on?

The auto-detection logic in _fit_label_encoders for undeclared object-dtype columns - is the warning message clear enough, and is stacklevel=4 correct for the call depth?
Whether label_encoders should be exposed in the class docstring under Parameters
The column-by-column to_numpy(dtype=float) approach in __getitem__ vs the previous torch.tensor(data_feat_vals) — happy to discuss alternatives

#### Did you add any tests for the change?

Yes, 7 new tests added to 
test_d1.py:

test_label_encoders_fitted_on_init - encoders are created for all cat columns on init
test_label_encoders_cover_all_cat_values - encoder classes contain all unique values
test_getitem_cat_columns_are_numeric - x tensor is fully numeric after encoding
test_getitem_encoded_values_are_integers - encoded values are integer-valued floats
test_no_label_encoders_for_numeric_only - no encoders created when cat is empty
test_custom_label_encoder_is_used - pre-fitted encoder passed in is used as-is
test_label_encoder_inverse_transform - inverse transform recovers original values

#### Any other comments?
Checked open PRs and issues before starting - no existing PR was covering this specific item from #1974.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [X] Added/modified tests
- [X] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`

<!--
Thanks for contributing!
-->

