### PR TITLE
Convert docstrings in models/nn to NumPy style

### DIFF
--- a/pytorch_forecasting/models/nn/embeddings.py
+++ b/pytorch_forecasting/models/nn/embeddings.py
@@ -50,8 +50,9 @@ class MultiEmbedding(nn.Module):
 
         Enabled for static and dynamic categories (i.e. 3 dimensions for batch x time x categories).
 
-        Args:
-            embedding_sizes (Union[Dict[str, Tuple[int, int]], Dict[str, int], List[int], List[Tuple[int, int]]]):
+        Parameters
+        ----------
+            embedding_sizes : Union[Dict[str, Tuple[int, int]], Dict[str, int], List[int], List[Tuple[int, int]]]
                 either
 
                 * dictionary of embedding sizes, e.g. ``{'cat1': (10, 3)}``
@@ -67,14 +68,18 @@ class MultiEmbedding(nn.Module):
 
                 If input is provided as list, output will be a single tensor of shape batch x (optional) time x
                 sum(embedding_sizes). Otherwise, output is a dictionary of embedding tensors.
-            x_categoricals (List[str]): list of categorical variables that are used as input.
-            categorical_groups (Dict[str, List[str]]): dictionary of categories that should be summed up in an
+            x_categoricals : List[str]
+                list of categorical variables that are used as input.
+            categorical_groups : Dict[str, List[str]]
+                dictionary of categories that should be summed up in an
                 embedding bag, e.g. ``{'cat1': ['cat2', 'cat3']}`` indicates that a new categorical variable ``'cat1'``
                 is mapped to an embedding bag containing the second and third categorical variables.
                 Defaults to empty dictionary.
-            embedding_paddings (List[str]): list of categorical variables for which the value 0 is mapped to a zero
+            embedding_paddings : List[str]
+                list of categorical variables for which the value 0 is mapped to a zero
                 embedding vector. Defaults to empty list.
-            max_embedding_size (int, optional): if embedding size defined by ``embedding_sizes`` is larger than
+            max_embedding_size : int, optional
+                if embedding size defined by ``embedding_sizes`` is larger than
                 ``max_embedding_size``, it will be constrained. Defaults to None.
         """  # noqa: E501
         if categorical_groups is None:
@@ -188,12 +193,16 @@ class MultiEmbedding(nn.Module):
 
     def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
         """
-        Args:
-            x (torch.Tensor): input tensor of shape batch x (optional) time x categoricals in the order of
+        Parameters
+        ----------
+            x : torch.Tensor
+                input tensor of shape batch x (optional) time x categoricals in the order of
                 ``x_categoricals``.
 
-        Returns:
-            Union[Dict[str, torch.Tensor], torch.Tensor]: dictionary of category names to embeddings
+        Returns
+        -------
+            Union[Dict[str, torch.Tensor], torch.Tensor]
+                dictionary of category names to embeddings
                 of shape batch x (optional) time x embedding_size if ``embedding_size`` is given as dictionary.
                 Otherwise, returns the embedding of shape batch x (optional) time x sum(embedding_sizes).
                 Query attribute ``output_size`` to get the size of the output(s).

--- a/pytorch_forecasting/models/nn/rnn.py
+++ b/pytorch_forecasting/models/nn/rnn.py
@@ -29,13 +29,19 @@ class RNN(ABC, nn.RNNBase):
         """
         Mask the hidden_state where there is no encoding.
 
-        Args:
-            hidden_state (HiddenState): hidden state where some entries need replacement
-            no_encoding (torch.BoolTensor): positions that need replacement
-            initial_hidden_state (HiddenState): hidden state to use for replacement
+        Parameters
+        ----------
+            hidden_state : HiddenState
+                hidden state where some entries need replacement
+            no_encoding : torch.BoolTensor
+                positions that need replacement
+            initial_hidden_state : HiddenState
+                hidden state to use for replacement
 
-        Returns:
-            HiddenState: hidden state with propagated initial hidden state where appropriate
+        Returns
+        -------
+            HiddenState
+                hidden state with propagated initial hidden state where appropriate
         """  # noqa: E501
         pass
 
@@ -44,11 +50,15 @@ class RNN(ABC, nn.RNNBase):
         """
         Initialise a hidden_state.
 
-        Args:
-            x (torch.Tensor): network input
+        Parameters
+        ----------
+            x : torch.Tensor
+                network input
 
-        Returns:
-            HiddenState: default (zero-like) hidden state
+        Returns
+        -------
+            HiddenState
+                default (zero-like) hidden state
         """
         pass
 
@@ -59,12 +69,17 @@ class RNN(ABC, nn.RNNBase):
         """
         Duplicate the hidden_state n_samples times.
 
-        Args:
-            hidden_state (HiddenState): hidden state to repeat
-            n_samples (int): number of repetitions
+        Parameters
+        ----------
+            hidden_state : HiddenState
+                hidden state to repeat
+            n_samples : int
+                number of repetitions
 
-        Returns:
-            HiddenState: repeated hidden state
+        Returns
+        -------
+            HiddenState
+                repeated hidden state
         """
         pass
 
@@ -80,17 +95,24 @@ class RNN(ABC, nn.RNNBase):
 
         Functions as normal for RNN. Only changes output if lengths are defined.
 
-        Args:
-            x (Union[rnn.PackedSequence, torch.Tensor]): input to RNN. either packed sequence or tensor of
+        Parameters
+        ----------
+            x : Union[rnn.PackedSequence, torch.Tensor]
+                input to RNN. either packed sequence or tensor of
                 padded sequences
-            hx (HiddenState, optional): hidden state. Defaults to None.
-            lengths (torch.LongTensor, optional): lengths of sequences. If not None, used to determine correct returned
+            hx : HiddenState, optional
+                hidden state. Defaults to None.
+            lengths : torch.LongTensor, optional
+                lengths of sequences. If not None, used to determine correct returned
                 hidden state. Can contain zeros. Defaults to None.
-            enforce_sorted (bool, optional): if lengths are passed, determines if RNN expects them to be sorted.
+            enforce_sorted : bool, optional
+                if lengths are passed, determines if RNN expects them to be sorted.
                 Defaults to True.
 
-        Returns:
-            Tuple[Union[rnn.PackedSequence, torch.Tensor], HiddenState]: output and hidden state.
+        Returns
+        -------
+            Tuple[Union[rnn.PackedSequence, torch.Tensor], HiddenState]
+                output and hidden state.
                 Output is packed sequence if input has been a packed sequence.
         """  # noqa: E501
         if isinstance(x, rnn.PackedSequence) or lengths is None:
@@ -230,11 +252,15 @@ def get_rnn(cell_type: type[RNN] | str) -> type[RNN]:
     """
     Get LSTM or GRU.
 
-    Args:
-        cell_type (Union[RNN, str]): "LSTM" or "GRU"
+    Parameters
+    ----------
+        cell_type : Union[RNN, str]
+            "LSTM" or "GRU"
 
-    Returns:
-        Type[RNN]: returns GRU or LSTM RNN module
+    Returns
+    -------
+        Type[RNN]
+            returns GRU or LSTM RNN module
     """
     if isinstance(cell_type, RNN):
         rnn = cell_type


### PR DESCRIPTION
Closes part of #2066

This PR migrates the docstrings in most files of [nn](https://github.com/sktime/pytorch-forecasting/tree/main/pytorch_forecasting/models/nn) from Google style to NumPy (numpydoc) style for documentation consistency.

Files modified:
- embeddings.py
- rnn.py

No functional changes were made.