### PR TITLE
[MNT] Remove `pandas 3` warnings

### DIFF
--- a/pytorch_forecasting/data/timeseries/_timeseries.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries.py
@@ -1003,7 +1003,9 @@ class TimeSeriesDataSet(Dataset):
         ), "Timeseries index should be of type integer"
         # numeric categoricals which can cause issues in tensorborad logging
         category_columns = data.head(1).select_dtypes("category").columns
-        object_columns = data.head(1).select_dtypes(object).columns
+        object_columns = (
+            data.head(1).select_dtypes(include=["object", "string"]).columns
+        )
         for name in self.flat_categoricals:
             if name not in data.columns:
                 raise KeyError(f"variable {name} specified but not found in data")
@@ -1882,7 +1884,7 @@ class TimeSeriesDataSet(Dataset):
         if predict_mode and "sequence_id" in df_index.columns:
             minimal_columns.append("sequence_id")
 
-        df_index = df_index[minimal_columns].astype("int32", copy=False)
+        df_index = df_index[minimal_columns].astype("int32")
         return df_index.reset_index(drop=True)
 
     def filter(self, filter_func: Callable, copy: bool = True) -> TimeSeriesDataType:

--- a/pytorch_forecasting/data/timeseries/_timeseries_v2.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries_v2.py
@@ -131,7 +131,12 @@ class TimeSeries(Dataset):
             if col not in [self.time] + self._group + [self.weight] + self._target
         ]
         if self._group:
-            self._groups = self.data.groupby(self._group).groups
+            group_arg = (
+                self._group[0]
+                if isinstance(self._group, (list, tuple)) and len(self._group) == 1
+                else self._group
+            )
+            self._groups = self.data.groupby(group_arg).groups
             self._group_ids = list(self._groups.keys())
         else:
             self._groups = {"_single_group": self.data.index}
@@ -255,7 +260,12 @@ class TimeSeries(Dataset):
 
         if data_future is not None:
             if _group:
-                future_mask = self.data_future.groupby(_group).groups[group_id]
+                group_arg = (
+                    self._group[0]
+                    if isinstance(self._group, (list, tuple)) and len(self._group) == 1
+                    else self._group
+                )
+                future_mask = self.data_future.groupby(group_arg).groups[group_id]
                 future_data = self.data_future.loc[future_mask]
             else:
                 future_data = self.data_future

--- a/tests/test_data/test_timeseries.py
+++ b/tests/test_data/test_timeseries.py
@@ -727,8 +727,8 @@ def test_pytorch_unwriteable_data():
     already have been issued.
     """
     # save current mode
-    copy_on_write = pd.options.mode.copy_on_write
-    pd.options.mode.copy_on_write = True
+    # copy_on_write = pd.options.mode.copy_on_write
+    # pd.options.mode.copy_on_write = True
 
     # Create a small dataset
     data = pd.DataFrame(
@@ -762,7 +762,7 @@ def test_pytorch_unwriteable_data():
         next(iter(dataset))
 
         # reset original mode
-        pd.options.mode.copy_on_write = copy_on_write
+        # pd.options.mode.copy_on_write = copy_on_write
 
         # Check if the specific warning was triggered
         to_catch = "The given NumPy array is not writable, and PyTorch"


### PR DESCRIPTION
`pandas 3` introduced some deprecations which were clogging up the CI. This PR tries to remove these warnings
Currently removed warnings:

- [x] ```In a future version, the keys of `groups` will be a tuple with a single element, e.g. (group_id,) , instead of a scalar, e.g. group_id, when grouping by a list with a single element. Use ``df.groupby(by='a').groups`` instead of ``df.groupby(by=['a']).groups`` to avoid this warning```
- [x] ```For backward compatibility, 'str' dtypes are included by select_dtypes when 'object' dtype is specified. This behavior is deprecated and will be removed in a future version. Explicitly pass 'str' to `include` to select them, or to `exclude` to remove them and silence this warning. ```
- [x] ```The 'mode.copy_on_write' option is deprecated. Copy-on-Write can no longer be disabled (it is always enabled with pandas >= 3.0), and setting the option has no impact. This option will be removed in pandas 4.0.```