### PR TITLE
[BUG] fix wrong-scale distribution sampling in autoregressive decoding

### DIFF
--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -2451,7 +2451,7 @@ class AutoRegressiveBaseModel(BaseModel):
                     prediction, lambda x: x.reshape(x.size(0) * n_samples, 1, -1)
                 )
             else:
-                prediction = self.loss.sample(normalized_prediction_parameters, 1)
+                prediction = self.loss.sample(prediction_parameters, 1)
 
         else:
             prediction = prediction_parameters


### PR DESCRIPTION


## Reference Issues/PRs

None — found this during a manual code audit. No existing issue for this.

## What does this implement/fix? Explain your changes.

Found a sneaky bug in `BaseModel.output_to_prediction` where the `n_samples == 1` branch was sampling from normalized-space distribution parameters instead of the rescaled real-space parameters.

Here's what happens: line 2432 correctly rescales the parameters via `transform_output` into `prediction_parameters`. The `n_samples &gt; 1` path uses this rescaled variable just fine, but the `n_samples == 1` path was accidentally passing the original `normalized_prediction_parameters` to `self.loss.sample()`.

This bites any model using `DistributionLoss` with autoregressive decoding when `n_samples=1` (which is the default). Training is fine since it uses teacher forcing. DeepAR avoids this by always passing `n_samples &gt; 1`, but `RecurrentNetwork` with a `DistributionLoss` would spit out wrong predictions at eval time.

**Fix:** Just one line — changed `normalized_prediction_parameters` to `prediction_parameters` on line 2454.

## What should a reviewer concentrate their feedback on?

- Double-check that `prediction_parameters` (the rescaled ones) is indeed the right input for `self.loss.sample()` on the `n_samples == 1` path, so it matches what the `n_samples &gt; 1` path does
- Whether we should add a regression test using `RecurrentNetwork` + `NormalDistributionLoss` in eval mode

## Did you add any tests for the change?

Not yet — wanted to check if reviewers think it's worth it first. If so, I can add a minimal repro: basically just `RecurrentNetwork` with a `DistributionLoss`, then call `model.predict()` (which triggers autoregressive eval with `n_samples=1`).


## PR checklist

- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.