### PR TITLE
Fix ReadTheDocs configuration for versions 1.1.0 and 1.1.1

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,28 +1,12 @@
-# .readthedocs.yml
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
 version: 2
-
-# Build documentation in the docs/ directory with Sphinx
-# reference: https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx
-sphinx:
-  configuration: docs/source/conf.py
-  # fail_on_warning: true
-
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
-# Optionally build your docs in additional formats such as PDF and ePub
-formats:
-  - htmlzip
 
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.10"
+
+sphinx:
+  configuration: docs/source/conf.py
 
 python:
   install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ docs = [
   "nbconvert",
   "recommonmark",
   "docutils",
+  "sphinx-rtd-theme",
+  "myst-parser",
 ]
 
 # Core Dep set just before the lightning 2.6 release


### PR DESCRIPTION
## Description

Fixes failing ReadTheDocs builds for versions 1.1.0 and 1.1.1 caused by outdated
`.readthedocs.yml` configuration and missing documentation dependencies.

This PR updates the ReadTheDocs configuration and ensures required Sphinx
dependencies are available so that documentation builds successfully.

Fixes #1678

## Changes

- Updated `.readthedocs.yml` to use modern configuration
- Set Python version to 3.10 for compatibility
- Added Sphinx configuration path
- Added missing documentation dependencies in `pyproject.toml`
  - sphinx-rtd-theme
  - myst-parser

## Type of change

- [x] Documentation fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Code follows project style guidelines
- [x] Changes tested locally
- [x] Documentation build verified