### PR TITLE
Fix incorrect sampler example in TimeSeriesDataSet.to_dataloader docu…

### DIFF
--- a/pytorch_forecasting/data/timeseries/_timeseries.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries.py
@@ -2624,7 +2624,7 @@ class TimeSeriesDataSet(Dataset):
 
             # length of probabilities for sampler have to be equal
             # to the length of index
-            probabilities = np.sqrt(1 + data.loc[dataset.index, "target"])
+            probabilities = np.sqrt(1 + data.loc[data.index, "target"])
             sampler = WeightedRandomSampler(probabilities, len(probabilities))
             dataset.to_dataloader(train=True, sampler=sampler, shuffle=False)
         """


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1242

#### What does this implement/fix? Explain your changes.
This PR fixes an incorrect example in the `TimeSeriesDataSet.to_dataloader` documentation.

The example used:
`dataset.index` when indexing the dataframe:

probabilities = np.sqrt(1 + data.loc[dataset.index, "target"])

This causes the following error:

ValueError: Cannot index with multidimensional key

The example has been corrected to use `data.index` instead:

probabilities = np.sqrt(1 + data.loc[data.index, "target"])

This ensures the example works correctly when creating a `WeightedRandomSampler`.

#### What should a reviewer concentrate their feedback on?
- Correctness of the updated documentation example.
- Whether the example now correctly reflects how `WeightedRandomSampler` should be used with `TimeSeriesDataSet`.

#### Did you add any tests for the change?
No tests were added because this change only affects a documentation example and does not modify runtime functionality.

#### Any other comments?
This change aligns the example with the correct usage described in Issue #1242.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.