### PR TITLE
[ENH] add UniTS v2 model (#2158)

### DIFF
--- a/docs/source/tutorials/stallion.ipynb
+++ b/docs/source/tutorials/stallion.ipynb
@@ -41,7 +41,6 @@
    "source": [
     "import warnings\n",
     "\n",
-    "\n",
     "warnings.filterwarnings(\"ignore\")  # avoid printing out absolute paths"
    ]
   },

--- a/pytorch_forecasting/models/__init__.py
+++ b/pytorch_forecasting/models/__init__.py
@@ -20,6 +20,7 @@ from pytorch_forecasting.models.temporal_fusion_transformer import (
 )
 from pytorch_forecasting.models.tide import TiDEModel
 from pytorch_forecasting.models.timexer import TimeXer
+from pytorch_forecasting.models.units import UniTS_pkg_v2
 from pytorch_forecasting.models.xlstm import xLSTMTime
 
 __all__ = [

--- a/pytorch_forecasting/models/units/__init__.py
+++ b/pytorch_forecasting/models/units/__init__.py
@@ -1,0 +1,8 @@
+"""
+UniTS: Unified Time Series Model for time series forecasting.
+"""
+
+from pytorch_forecasting.models.units._units_v2 import UniTS
+from pytorch_forecasting.models.units._units_pkg_v2 import UniTS_pkg_v2
+
+__all__ = ["UniTS", "UniTS_pkg_v2"]

--- a/pytorch_forecasting/models/units/__init__.py
+++ b/pytorch_forecasting/models/units/__init__.py
@@ -2,7 +2,7 @@
 UniTS: Unified Time Series Model for time series forecasting.
 """
 
-from pytorch_forecasting.models.units._units_v2 import UniTS
 from pytorch_forecasting.models.units._units_pkg_v2 import UniTS_pkg_v2
+from pytorch_forecasting.models.units._units_v2 import UniTS
 
 __all__ = ["UniTS", "UniTS_pkg_v2"]

--- a/pytorch_forecasting/models/units/_units_pkg_v2.py
+++ b/pytorch_forecasting/models/units/_units_pkg_v2.py
@@ -1,0 +1,54 @@
+from pytorch_forecasting.base._base_pkg import Base_pkg
+
+__all__ = ["UniTS_pkg_v2"]
+
+
+class UniTS_pkg_v2(Base_pkg):
+    """
+    UniTS: Unified Time Series Model.
+
+    Reference: https://arxiv.org/abs/2403.00131
+    """
+
+    _tags = {
+        "info:name": "UniTS",
+        "authors": ["sohamukute"],
+        "capability:exogenous": True,
+        "capability:multivariate": True,
+        "capability:pred_int": False,
+        "capability:flexible_history_length": False,
+    }
+
+    @classmethod
+    def get_cls(cls):
+        from pytorch_forecasting.models.units._units_v2 import UniTS
+
+        return UniTS
+
+    @classmethod
+    def get_datamodule_cls(cls):
+        from pytorch_forecasting.data._tslib_data_module import TslibDataModule
+
+        return TslibDataModule
+
+    @classmethod
+    def get_test_train_params(cls):
+        return [
+            {
+                "patch_len": 8,
+                "stride": 4,
+                "datamodule_cfg": {"context_length": 12, "prediction_length": 4},
+            },
+            {
+                "d_model": 32,
+                "n_heads": 4,
+                "patch_len": 8,
+                "stride": 4,
+                "datamodule_cfg": {"context_length": 12, "prediction_length": 4},
+            },
+            {
+                "patch_len": 8,
+                "stride": 4,
+                "datamodule_cfg": {"context_length": 16, "prediction_length": 4},
+            },
+        ]

--- a/pytorch_forecasting/models/units/_units_v2.py
+++ b/pytorch_forecasting/models/units/_units_v2.py
@@ -3,8 +3,8 @@ UniTS: Unified Time Series Model for PyTorch Forecasting.
 """
 
 import math
-import warnings
 from typing import Any
+import warnings
 
 import torch
 import torch.nn as nn

--- a/pytorch_forecasting/models/units/_units_v2.py
+++ b/pytorch_forecasting/models/units/_units_v2.py
@@ -1,0 +1,327 @@
+"""
+UniTS: Unified Time Series Model for PyTorch Forecasting.
+"""
+
+import math
+import warnings
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.optim import Optimizer
+
+from pytorch_forecasting.models.base._tslib_base_model_v2 import TslibBaseModel
+
+
+class _PatchEmbedding(nn.Module):
+    """Project strided patches of a multivariate time series into d_model space.
+
+    Uses channel-independent patching: each channel's patches are projected
+    separately with a shared Linear(patch_len, d_model), then averaged across
+    channels. This matches the channel-independent approach in the original paper
+    and makes the module robust to any number of input channels at runtime.
+
+    Parameters
+    ----------
+    patch_len : int
+        Length of each patch window in time steps.
+    stride : int
+        Stride between consecutive patches.
+    d_model : int
+        Output embedding dimension.
+    dropout : float
+        Dropout probability.
+    """
+
+    def __init__(self, patch_len: int, stride: int, d_model: int, dropout: float = 0.1):
+        super().__init__()
+        self.patch_len = patch_len
+        self.stride = stride
+        self.projection = nn.Linear(patch_len, d_model)
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Parameters
+        ----------
+        x : torch.Tensor
+            Shape (batch, seq_len, n_channels).
+
+        Returns
+        -------
+        torch.Tensor
+            Shape (batch, num_patches, d_model).
+        """
+        patches = x.unfold(dimension=1, size=self.patch_len, step=self.stride)
+        B, num_patches, C, P = patches.shape
+        patches = patches.permute(0, 2, 1, 3).contiguous().view(B * C, num_patches, P)
+        emb = self.drop(self.projection(patches))
+        emb = emb.view(B, C, num_patches, self.projection.out_features)
+        return emb.mean(dim=1)
+
+
+class _PositionalEncoding(nn.Module):
+    """Sinusoidal positional encoding.
+
+    Parameters
+    ----------
+    d_model : int
+        Embedding dimension.
+    max_len : int
+        Maximum sequence length.
+    dropout : float
+        Dropout probability.
+    """
+
+    def __init__(self, d_model: int, max_len: int = 512, dropout: float = 0.1):
+        super().__init__()
+        self.drop = nn.Dropout(dropout)
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        half = d_model // 2
+        div_term = torch.exp(
+            torch.arange(0, half, dtype=torch.float) * (-math.log(10000.0) / d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term[: pe[:, 0::2].size(1)])
+        pe[:, 1::2] = torch.cos(position * div_term[: pe[:, 1::2].size(1)])
+        self.register_buffer("pe", pe.unsqueeze(0))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.drop(x + self.pe[:, : x.size(1), :])
+
+
+class _TransformerBlock(nn.Module):
+    """Pre-norm transformer encoder block (MHSA + FFN).
+
+    Parameters
+    ----------
+    d_model : int
+        Model dimension.
+    n_heads : int
+        Number of attention heads.
+    d_ff : int
+        Feed-forward hidden dimension.
+    dropout : float
+        Dropout probability.
+    """
+
+    def __init__(self, d_model: int, n_heads: int, d_ff: int, dropout: float = 0.1):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.attn = nn.MultiheadAttention(
+            embed_dim=d_model, num_heads=n_heads, dropout=dropout, batch_first=True
+        )
+        self.ff = nn.Sequential(
+            nn.Linear(d_model, d_ff),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(d_ff, d_model),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        normed = self.norm1(x)
+        attn_out, _ = self.attn(normed, normed, normed)
+        x = x + attn_out
+        x = x + self.ff(self.norm2(x))
+        return x
+
+
+class UniTS(TslibBaseModel):
+    """
+    UniTS: Unified Time Series Model.
+
+    Patch-based transformer for multivariate time series forecasting.
+    Implements a simplified version of the architecture from the paper, using
+    channel-independent patching: each channel is projected separately with a
+    shared linear layer, then averaged across channels.
+
+    Parameters
+    ----------
+    loss : nn.Module
+        Loss function for training.
+    d_model : int, optional
+        Transformer model dimension. Default is 64.
+    n_heads : int, optional
+        Number of self-attention heads. Must divide d_model. Default is 8.
+    e_layers : int, optional
+        Number of transformer encoder layers. Default is 3.
+    d_ff : int, optional
+        Feed-forward hidden dimension. Default is 512.
+    dropout : float, optional
+        Dropout probability. Default is 0.1.
+    patch_len : int, optional
+        Patch length in time steps. Must be <= context_length. Default is 16.
+    stride : int, optional
+        Stride between patches. Default is 8.
+    prompt_len : int, optional
+        Number of learnable task-prompt tokens prepended to patch sequence.
+        Default is 10.
+    logging_metrics : list[nn.Module] or None, optional
+        Metrics to log during training.
+    optimizer : Optimizer or str or None, optional
+        Optimizer. Default is 'adam'.
+    optimizer_params : dict or None, optional
+        Optimizer parameters.
+    lr_scheduler : str or None, optional
+        Learning rate scheduler.
+    lr_scheduler_params : dict or None, optional
+        Scheduler parameters.
+    metadata : dict or None, optional
+        Dataset metadata provided by TslibDataModule.
+
+    References
+    ----------
+    .. [1] Gao, S. et al. (2024). UniTS: Building a Unified Time Series Model.
+       https://arxiv.org/abs/2403.00131
+    .. [2] https://github.com/mims-harvard/UniTS
+    """
+
+    @classmethod
+    def _pkg(cls):
+        """Package containing the model."""
+        from pytorch_forecasting.models.units._units_pkg_v2 import UniTS_pkg_v2
+
+        return UniTS_pkg_v2
+
+    def __init__(
+        self,
+        loss: nn.Module,
+        d_model: int = 64,
+        n_heads: int = 8,
+        e_layers: int = 3,
+        d_ff: int = 512,
+        dropout: float = 0.1,
+        patch_len: int = 16,
+        stride: int = 8,
+        prompt_len: int = 10,
+        logging_metrics: list[nn.Module] | None = None,
+        optimizer: Optimizer | str | None = "adam",
+        optimizer_params: dict | None = None,
+        lr_scheduler: str | None = None,
+        lr_scheduler_params: dict | None = None,
+        metadata: dict | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            loss=loss,
+            logging_metrics=logging_metrics,
+            optimizer=optimizer,
+            optimizer_params=optimizer_params,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_params=lr_scheduler_params,
+            metadata=metadata,
+        )
+
+        warnings.warn(
+            "UniTS is an experimental model implemented on TslibBaseModelV2. "
+            "It is an unstable version and may be subject to unannounced changes. "
+            "Please use with caution.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+        self.save_hyperparameters(ignore=["loss", "logging_metrics", "metadata"])
+
+        if d_model % n_heads != 0:
+            raise ValueError(
+                f"d_model ({d_model}) must be divisible by n_heads ({n_heads})."
+            )
+
+        if patch_len > self.context_length:
+            raise ValueError(
+                f"patch_len ({patch_len}) must not exceed "
+                f"context_length ({self.context_length})."
+            )
+
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.e_layers = e_layers
+        self.d_ff = d_ff
+        self.dropout = dropout
+        self.patch_len = patch_len
+        self.stride = stride
+        self.prompt_len = prompt_len
+
+        self._init_network()
+
+    def _init_network(self):
+        """Initialise model layers."""
+        self.num_patches = max(
+            1, (self.context_length - self.patch_len) // self.stride + 1
+        )
+
+        self.patch_embedding = _PatchEmbedding(
+            patch_len=self.patch_len,
+            stride=self.stride,
+            d_model=self.d_model,
+            dropout=self.dropout,
+        )
+
+        self.prompt_tokens = nn.Parameter(torch.empty(1, self.prompt_len, self.d_model))
+        nn.init.trunc_normal_(self.prompt_tokens, std=0.02)
+
+        self.pos_enc = _PositionalEncoding(
+            d_model=self.d_model,
+            max_len=self.prompt_len + self.num_patches + 16,
+            dropout=self.dropout,
+        )
+
+        self.encoder = nn.ModuleList(
+            [
+                _TransformerBlock(self.d_model, self.n_heads, self.d_ff, self.dropout)
+                for _ in range(self.e_layers)
+            ]
+        )
+
+        self.norm = nn.LayerNorm(self.d_model)
+
+        self.head = nn.Sequential(
+            nn.Flatten(start_dim=1),
+            nn.Linear(
+                self.num_patches * self.d_model,
+                self.prediction_length * self.target_dim,
+            ),
+        )
+
+    def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """
+        Parameters
+        ----------
+        x : dict[str, torch.Tensor]
+            Input batch. Uses ``history_target`` (batch, context_length, target_dim)
+            and optionally ``history_cont`` (batch, context_length, cont_dim).
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            ``prediction`` of shape (batch, prediction_length, target_dim).
+        """
+        target = x["history_target"]
+        B = target.size(0)
+
+        cont = x.get("history_cont")
+        if cont is not None and cont.size(-1) > 0:
+            src = torch.cat([cont, target], dim=-1)
+        else:
+            src = target
+
+        mean = src.mean(dim=1, keepdim=True)
+        std = src.std(dim=1, keepdim=True, unbiased=False) + 1e-5
+        src = (src - mean) / std
+
+        patch_emb = self.patch_embedding(src)
+        seq = torch.cat([self.prompt_tokens.expand(B, -1, -1), patch_emb], dim=1)
+        seq = self.pos_enc(seq)
+
+        for layer in self.encoder:
+            seq = layer(seq)
+        seq = self.norm(seq)
+
+        patch_out = seq[:, self.prompt_len : self.prompt_len + self.num_patches, :]
+        out = self.head(patch_out).view(B, self.prediction_length, self.target_dim)
+
+        target_mean = mean[:, :, -self.target_dim :]
+        target_std = std[:, :, -self.target_dim :]
+        return {"prediction": out * target_std + target_mean}

--- a/tests/test_models/test_units_v2.py
+++ b/tests/test_models/test_units_v2.py
@@ -88,15 +88,17 @@ class TestUniTSPkg:
             assert "prediction_length" in dm
             # patch_len must not exceed context_length
             patch_len = p.get("patch_len", 16)
-            assert patch_len <= dm["context_length"], (
-                f"patch_len={patch_len} exceeds context_length={dm['context_length']}"
-            )
+            assert (
+                patch_len <= dm["context_length"]
+            ), f"patch_len={patch_len} exceeds context_length={dm['context_length']}"
 
     def test_get_test_train_params_independent(self):
         """Each param dict must be independent — no shared mutable objects."""
         params = UniTS_pkg_v2.get_test_train_params()
         dm_ids = [id(p["datamodule_cfg"]) for p in params]
-        assert len(dm_ids) == len(set(dm_ids)), "datamodule_cfg dicts are shared objects"
+        assert len(dm_ids) == len(
+            set(dm_ids)
+        ), "datamodule_cfg dicts are shared objects"
 
 
 class TestUniTSForward:
@@ -159,7 +161,9 @@ class TestUniTSForward:
 
     def test_exogenous_features(self):
         """Model must accept and use continuous exogenous features."""
-        meta = _make_metadata(context_length=24, prediction_length=6, target_dim=2, cont_dim=3)
+        meta = _make_metadata(
+            context_length=24, prediction_length=6, target_dim=2, cont_dim=3
+        )
         model = _make_model(meta, d_model=32, n_heads=4, d_ff=64)
         model.eval()
         with torch.no_grad():
@@ -168,7 +172,9 @@ class TestUniTSForward:
 
     @pytest.mark.parametrize("pred_len", [1, 3, 12, 24])
     def test_prediction_lengths(self, pred_len):
-        meta = _make_metadata(context_length=48, prediction_length=pred_len, target_dim=2)
+        meta = _make_metadata(
+            context_length=48, prediction_length=pred_len, target_dim=2
+        )
         model = _make_model(meta, d_model=32, n_heads=4, d_ff=64)
         model.eval()
         with torch.no_grad():
@@ -177,7 +183,9 @@ class TestUniTSForward:
 
     @pytest.mark.parametrize("target_dim", [1, 4, 7])
     def test_target_dims(self, target_dim):
-        meta = _make_metadata(context_length=24, prediction_length=6, target_dim=target_dim)
+        meta = _make_metadata(
+            context_length=24, prediction_length=6, target_dim=target_dim
+        )
         model = _make_model(meta, d_model=32, n_heads=4, d_ff=64)
         model.eval()
         with torch.no_grad():

--- a/tests/test_models/test_units_v2.py
+++ b/tests/test_models/test_units_v2.py
@@ -1,0 +1,217 @@
+"""Tests for UniTS v2 model."""
+
+import inspect
+
+import pytest
+import torch
+import torch.nn as nn
+
+from pytorch_forecasting.models.units import UniTS_pkg_v2
+from pytorch_forecasting.models.units._units_v2 import UniTS
+
+
+def _make_metadata(
+    context_length=24,
+    prediction_length=6,
+    target_dim=3,
+    cont_dim=0,
+    cat_dim=0,
+    features="M",
+):
+    return {
+        "context_length": context_length,
+        "prediction_length": prediction_length,
+        "features": features,
+        "n_features": {
+            "target": target_dim,
+            "continuous": cont_dim,
+            "categorical": cat_dim,
+            "static_categorical": 0,
+            "static_continuous": 0,
+        },
+        "feature_indices": {
+            "target": list(range(target_dim)),
+            "continuous": list(range(cont_dim)),
+            "categorical": [],
+            "known": [],
+            "unknown": [],
+        },
+        "feature_names": {},
+    }
+
+
+def _make_model(metadata, **kwargs):
+    return UniTS(loss=nn.MSELoss(), metadata=metadata, **kwargs)
+
+
+def _make_batch(metadata, batch_size=2):
+    B = batch_size
+    T = metadata["context_length"]
+    C = metadata["n_features"]["target"]
+    Cc = metadata["n_features"]["continuous"]
+    batch = {
+        "history_target": torch.randn(B, T, C),
+        "history_time_idx": torch.arange(T).unsqueeze(0).expand(B, -1),
+        "target_scale": {
+            "scale": torch.ones(B, 1, C),
+            "center": torch.zeros(B, 1, C),
+        },
+    }
+    if Cc > 0:
+        batch["history_cont"] = torch.randn(B, T, Cc)
+    return batch
+
+
+class TestUniTSPkg:
+    """Tests for UniTS_pkg_v2."""
+
+    def test_get_cls(self):
+        assert UniTS_pkg_v2.get_cls().__name__ == "UniTS"
+
+    def test_pkg_tags(self):
+        instance = UniTS_pkg_v2()
+        assert instance.get_tag("info:name") == "UniTS"
+        assert instance.get_tag("capability:multivariate") is True
+        assert instance.get_tag("capability:exogenous") is True
+        assert instance.get_tag("capability:pred_int") is False
+
+    def test_get_datamodule_cls(self):
+        assert UniTS_pkg_v2.get_datamodule_cls() is not None
+
+    def test_get_test_train_params(self):
+        params = UniTS_pkg_v2.get_test_train_params()
+        assert isinstance(params, list) and len(params) > 0
+        for p in params:
+            assert "datamodule_cfg" in p
+            dm = p["datamodule_cfg"]
+            assert "context_length" in dm
+            assert "prediction_length" in dm
+            # patch_len must not exceed context_length
+            patch_len = p.get("patch_len", 16)
+            assert patch_len <= dm["context_length"], (
+                f"patch_len={patch_len} exceeds context_length={dm['context_length']}"
+            )
+
+    def test_get_test_train_params_independent(self):
+        """Each param dict must be independent — no shared mutable objects."""
+        params = UniTS_pkg_v2.get_test_train_params()
+        dm_ids = [id(p["datamodule_cfg"]) for p in params]
+        assert len(dm_ids) == len(set(dm_ids)), "datamodule_cfg dicts are shared objects"
+
+
+class TestUniTSForward:
+    """Forward pass shape and numerical correctness."""
+
+    @pytest.fixture
+    def meta(self):
+        return _make_metadata()
+
+    def test_output_shape_default(self, meta):
+        model = _make_model(meta)
+        model.eval()
+        with torch.no_grad():
+            out = model(_make_batch(meta))
+        assert "prediction" in out
+        assert out["prediction"].shape == (2, 6, 3)
+
+    def test_output_shape_small_dmodel(self, meta):
+        model = _make_model(meta, d_model=32, n_heads=4, d_ff=64)
+        model.eval()
+        with torch.no_grad():
+            out = model(_make_batch(meta))
+        assert out["prediction"].shape == (2, 6, 3)
+
+    def test_output_shape_single_layer(self, meta):
+        model = _make_model(meta, e_layers=1, d_model=32, n_heads=4, d_ff=64)
+        model.eval()
+        with torch.no_grad():
+            out = model(_make_batch(meta))
+        assert out["prediction"].shape == (2, 6, 3)
+
+    def test_no_nan(self, meta):
+        model = _make_model(meta)
+        model.eval()
+        with torch.no_grad():
+            out = model(_make_batch(meta))
+        assert not torch.isnan(out["prediction"]).any()
+
+    def test_no_inf(self, meta):
+        model = _make_model(meta)
+        model.eval()
+        with torch.no_grad():
+            out = model(_make_batch(meta))
+        assert not torch.isinf(out["prediction"]).any()
+
+    def test_pkg_classmethod(self):
+        assert UniTS._pkg().__name__ == "UniTS_pkg_v2"
+
+    def test_gradients_flow(self, meta):
+        """Loss.backward() must not raise and must produce non-zero gradients."""
+        model = _make_model(meta, d_model=32, n_heads=4, d_ff=64)
+        model.train()
+        out = model(_make_batch(meta))
+        target = torch.randn(2, 6, 3)
+        loss = nn.MSELoss()(out["prediction"], target)
+        loss.backward()
+        grads = [p.grad for p in model.parameters() if p.grad is not None]
+        assert len(grads) > 0
+        assert all(not torch.isnan(g).any() for g in grads)
+
+    def test_exogenous_features(self):
+        """Model must accept and use continuous exogenous features."""
+        meta = _make_metadata(context_length=24, prediction_length=6, target_dim=2, cont_dim=3)
+        model = _make_model(meta, d_model=32, n_heads=4, d_ff=64)
+        model.eval()
+        with torch.no_grad():
+            out = model(_make_batch(meta))
+        assert out["prediction"].shape == (2, 6, 2)
+
+    @pytest.mark.parametrize("pred_len", [1, 3, 12, 24])
+    def test_prediction_lengths(self, pred_len):
+        meta = _make_metadata(context_length=48, prediction_length=pred_len, target_dim=2)
+        model = _make_model(meta, d_model=32, n_heads=4, d_ff=64)
+        model.eval()
+        with torch.no_grad():
+            out = model(_make_batch(meta))
+        assert out["prediction"].shape == (2, pred_len, 2)
+
+    @pytest.mark.parametrize("target_dim", [1, 4, 7])
+    def test_target_dims(self, target_dim):
+        meta = _make_metadata(context_length=24, prediction_length=6, target_dim=target_dim)
+        model = _make_model(meta, d_model=32, n_heads=4, d_ff=64)
+        model.eval()
+        with torch.no_grad():
+            out = model(_make_batch(meta))
+        assert out["prediction"].shape == (2, 6, target_dim)
+
+
+class TestUniTSParams:
+    """Parameter validation."""
+
+    def test_d_model_not_divisible_by_n_heads(self):
+        with pytest.raises(ValueError, match="d_model"):
+            UniTS(loss=nn.MSELoss(), metadata=_make_metadata(), d_model=33, n_heads=8)
+
+    def test_patch_len_exceeds_context_length(self):
+        with pytest.raises(ValueError, match="patch_len"):
+            UniTS(
+                loss=nn.MSELoss(),
+                metadata=_make_metadata(context_length=8),
+                patch_len=16,
+            )
+
+    def test_default_hyperparameters(self):
+        sig = inspect.signature(UniTS.__init__)
+        defaults = {
+            k: v.default
+            for k, v in sig.parameters.items()
+            if v.default is not inspect.Parameter.empty
+        }
+        assert defaults["d_model"] == 64
+        assert defaults["n_heads"] == 8
+        assert defaults["e_layers"] == 3
+        assert defaults["d_ff"] == 512
+        assert defaults["dropout"] == 0.1
+        assert defaults["patch_len"] == 16
+        assert defaults["stride"] == 8
+        assert defaults["prompt_len"] == 10


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2158

#### What does this implement/fix? Explain your changes.

Adds UniTS (Gao et al., 2024) as a v2 model. Followed the same pattern as SAMformer/DLinear/TimeXer.

Patch-based transformer  overlapping patches, channel-independent projection (shared linear per channel, mean-pooled), learnable prompt tokens for task conditioning, sinusoidal PE, pre-norm transformer encoder, RevIN.

New files are `_units_v2.py`, `_units_pkg_v2.py`, `__init__.py` under `models/units/` and a test file.

#### What should a reviewer concentrate their feedback on?

The custom `_PatchEmbedding`/`_PositionalEncoding`/`_TransformerBlock` submodules  not sure if I should be reusing existing repo layers instead, would appreciate feedback on that.

#### Did you add any tests for the change?

Yes, `tests/test_models/test_units_v2.py`. 34 tests pass (23 unit + 11 integration).

#### Any other comments?

First contribution, so let me know if anything's off. Happy to fix.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.