### PR TITLE
[DOC] Migrate AttentionLayer docstring to NumPy style

### DIFF
--- a/pytorch_forecasting/layers/_attention/_attention_layer.py
+++ b/pytorch_forecasting/layers/_attention/_attention_layer.py
@@ -14,13 +14,19 @@ class AttentionLayer(nn.Module):
     """
     Attention layer that combines query, key, and value projections with an attention
     mechanism.
-    Args:
-        attention (nn.Module): Attention mechanism to use.
-        d_model (int): Dimension of the model.
-        n_heads (int): Number of attention heads.
-        d_keys (int, optional): Dimension of the keys. Defaults to d_model // n_heads.
-        d_values (int, optional):
-            Dimension of the values. Defaults to d_model // n_heads.
+
+    Parameters
+    ----------
+    attention : nn.Module
+        Attention mechanism to use.
+    d_model : int
+        Dimension of the model.
+    n_heads : int
+        Number of attention heads.
+    d_keys : int, optional
+        Dimension of the keys. Defaults to ``d_model // n_heads``.
+    d_values : int, optional
+        Dimension of the values. Defaults to ``d_model // n_heads``.
     """
 
     def __init__(self, attention, d_model, n_heads, d_keys=None, d_values=None):


### PR DESCRIPTION
## Summary

- Converts `AttentionLayer` class docstring in `pytorch_forecasting/layers/_attention/_attention_layer.py` from Google style to NumPy style, consistent with the rest of the sktime ecosystem and already-migrated files like `MovingAvg` and `NHiTS`.

## Changes

- `Args:` → `Parameters\n----------`
- Parameter descriptions reformatted to `name : type` on one line, description indented below
- Default values wrapped in double backticks for RST compatibility

## Related

Follows the same pattern as recently merged docstring migrations (e.g. `_moving_avg_filter.py`, `_encoder.py`).