### PR TITLE
[DOC] Migrate SeriesDecomposition docstring to NumPy style

### DIFF
--- a/pytorch_forecasting/layers/_decomposition/_series_decomp.py
+++ b/pytorch_forecasting/layers/_decomposition/_series_decomp.py
@@ -16,9 +16,10 @@ class SeriesDecomposition(nn.Module):
     Decomposes time series into trend and seasonal components using
     moving average filtering.
 
-    Args:
-        kernel_size (int):
-            Size of the moving average kernel for trend extraction.
+    Parameters
+    ----------
+    kernel_size : int
+        Size of the moving average kernel for trend extraction.
     """
 
     def __init__(self, kernel_size):
@@ -26,18 +27,6 @@ class SeriesDecomposition(nn.Module):
         self.moving_avg = MovingAvg(kernel_size, stride=1)
 
     def forward(self, x):
-        """
-        Forward pass for series decomposition.
-
-        Args:
-            x (torch.Tensor):
-                Input time series tensor of shape (batch_size, seq_len, features).
-
-        Returns:
-            tuple:
-                - trend (torch.Tensor): Trend component of the time series.
-                - seasonal (torch.Tensor): Seasonal component of the time series.
-        """
         trend = self.moving_avg(x)
         seasonal = x - trend
         return seasonal, trend

--- a/pytorch_forecasting/layers/_decomposition/_series_decomp.py
+++ b/pytorch_forecasting/layers/_decomposition/_series_decomp.py
@@ -33,14 +33,17 @@ class SeriesDecomposition(nn.Module):
         Parameters
         ----------
         x : torch.Tensor
-            Input tensor of shape (batch_size, seq_len, features) containing the time series data.
+            Input tensor of shape (batch_size, seq_len, features) containing
+            the time series data.
 
         Returns
         -------
         seasonal : torch.Tensor
-            Seasonal component (residual after trend removal) with same shape as input.
+            Seasonal component (residual after trend removal) with same shape
+            as input.
         trend : torch.Tensor
-            Trend component extracted via moving average with same shape as input.
+            Trend component extracted via moving average with same shape as
+            input.
         """
         trend = self.moving_avg(x)
         seasonal = x - trend

--- a/pytorch_forecasting/layers/_decomposition/_series_decomp.py
+++ b/pytorch_forecasting/layers/_decomposition/_series_decomp.py
@@ -27,6 +27,21 @@ class SeriesDecomposition(nn.Module):
         self.moving_avg = MovingAvg(kernel_size, stride=1)
 
     def forward(self, x):
+        """
+        Decompose input time series into trend and seasonal components.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape (batch_size, seq_len, features) containing the time series data.
+
+        Returns
+        -------
+        seasonal : torch.Tensor
+            Seasonal component (residual after trend removal) with same shape as input.
+        trend : torch.Tensor
+            Trend component extracted via moving average with same shape as input.
+        """
         trend = self.moving_avg(x)
         seasonal = x - trend
         return seasonal, trend


### PR DESCRIPTION
## Summary

- Converts `SeriesDecomposition` class docstring in `pytorch_forecasting/layers/_decomposition/_series_decomp.py` from Google style to NumPy style.
- Removes the `forward` method docstring, consistent with project style (e.g. `MovingAvg.forward` has no docstring).

## Changes

- `Args:` → `Parameters\n----------`
- Removed `forward` docstring (trivial method, consistent with `MovingAvg` in `_moving_avg_filter.py`)