### PR TITLE
[ENH] add configurable window stride to v2 data module

### DIFF
--- a/pytorch_forecasting/data/data_module.py
+++ b/pytorch_forecasting/data/data_module.py
@@ -73,6 +73,10 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
     randomize_length : Union[None, Tuple[float, float], bool], default=False
         Whether to randomize input sequence length.
+    window_stride : int, default=1
+        Step size between consecutive candidate windows. A value of 1 keeps the
+        current dense sliding-window behavior, while larger values only keep every
+        k-th valid window start.
     batch_size : int, default=32
         Batch size for DataLoader.
     num_workers : int, default=0
@@ -104,6 +108,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         ]
         | None = None,
         randomize_length: None | tuple[float, float] | bool = False,
+        window_stride: int = 1,
         batch_size: int = 32,
         num_workers: int = 0,
         train_val_test_split: tuple = (0.7, 0.15, 0.15),
@@ -119,6 +124,9 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         self.add_target_scales = add_target_scales
         self.add_encoder_length = add_encoder_length
         self.randomize_length = randomize_length
+        if window_stride < 1:
+            raise ValueError("window_stride must be at least 1.")
+        self.window_stride = window_stride
         self.target_normalizer = target_normalizer
         self.categorical_encoders = categorical_encoders
         self.scalers = scalers
@@ -606,7 +614,9 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 continue
 
             for start_idx in range(
-                0, max_prediction_idx - effective_min_prediction_idx
+                0,
+                max_prediction_idx - effective_min_prediction_idx,
+                self.window_stride,
             ):
                 if (
                     start_idx + self.max_encoder_length + self.max_prediction_length

--- a/tests/test_data/test_data_module.py
+++ b/tests/test_data/test_data_module.py
@@ -88,6 +88,7 @@ def test_init(sample_timeseries_data):
     assert dm.max_prediction_length == 12
     assert dm._min_encoder_length == 24
     assert dm._min_prediction_length == 12
+    assert dm.window_stride == 1
     assert dm.batch_size == 8
     assert dm.train_val_test_split == (0.7, 0.15, 0.15)
 
@@ -160,6 +161,43 @@ def test_create_windows(data_module):
         assert len(window) == 4
         assert window[2] == data_module.max_encoder_length
         assert window[3] == data_module.max_prediction_length
+
+
+def test_window_stride_reduces_window_density(sample_timeseries_data):
+    """Test that window_stride keeps only every k-th valid window start."""
+    dense_dm = EncoderDecoderTimeSeriesDataModule(
+        time_series_dataset=sample_timeseries_data,
+        max_encoder_length=24,
+        max_prediction_length=12,
+        window_stride=1,
+    )
+    sparse_dm = EncoderDecoderTimeSeriesDataModule(
+        time_series_dataset=sample_timeseries_data,
+        max_encoder_length=24,
+        max_prediction_length=12,
+        window_stride=3,
+    )
+
+    dense_dm.setup()
+    indices = dense_dm._train_indices[:1]
+    dense_windows = dense_dm._create_windows(indices)
+    sparse_windows = sparse_dm._create_windows(indices)
+
+    assert len(dense_windows) > len(sparse_windows)
+    assert [window[1] for window in sparse_windows] == list(
+        range(0, len(dense_windows), 3)
+    )
+
+
+def test_invalid_window_stride_raises(sample_timeseries_data):
+    """Test that invalid stride values are rejected."""
+    with pytest.raises(ValueError, match="window_stride must be at least 1"):
+        EncoderDecoderTimeSeriesDataModule(
+            time_series_dataset=sample_timeseries_data,
+            max_encoder_length=24,
+            max_prediction_length=12,
+            window_stride=0,
+        )
 
 
 def test_dataloader_creation(data_module):


### PR DESCRIPTION
#### Reference Issues/PRs

~~Implements the ptf-v2 "conditional sampling" idea mentioned on Discord by @agobbifbk~~
Implements a configurable window stride for the v2 native datamodule.

#### What does this implement/fix? Explain your changes.

This PR adds a `window_stride` parameter to `EncoderDecoderTimeSeriesDataModule` in the v2 data pipeline.

Currently, `_create_windows(...)` generates every valid sliding window by advancing one step at a time. This PR makes that behavior configurable by allowing users to keep every `k`-th valid window start instead.

With this change:
- `window_stride=1` preserves the current default behavior
- larger values reduce the density of generated windows, e.g. keeping every 6th or 24th valid start

This adds a configurable window-generation control to the v2 datamodule layer by letting users choose the stride between valid window starts. Similar window-selection controls are common in modern forecasting libraries and are useful for reducing redundant overlapping samples or matching deployment schedules.

Concretely, the PR:
- adds the `window_stride` argument to `EncoderDecoderTimeSeriesDataModule`
- validates that `window_stride >= 1`
- applies `window_stride` inside `_create_windows(...)` when iterating candidate start indices
- updates tests for the native v2 datamodule accordingly

#### Did you add any tests for the change?

Yes.

I added tests in `tests/test_data/test_data_module.py` to cover:
- the default `window_stride=1` behavior
- reduced window density when `window_stride > 1`
- validation failure when `window_stride < 1`

I also ran:

```bash
pytest tests/test_data/test_data_module.py
