### PR TITLE
[BUG] fix: replace undefined get_model_cls() with get_cls()

### DIFF
--- a/pytorch_forecasting/models/base/_base_object.py
+++ b/pytorch_forecasting/models/base/_base_object.py
@@ -21,7 +21,7 @@ class _BasePtForecaster_Common(_BaseObject):
         """Get model name."""
         name = cls.get_class_tags().get("info:name", None)
         if name is None:
-            name = cls.get_model_cls().__name__
+            name = cls.get_cls().__name__
         return name
 
     @classmethod
@@ -53,7 +53,7 @@ class _BasePtForecaster_Common(_BaseObject):
                 "get_test_params should either return a dict or list of dict."
             )
 
-        return cls.get_model_cls()(**params)
+        return cls.get_cls()(**params)
 
     @classmethod
     def create_test_instances_and_names(cls, parameter_set="default"):
@@ -93,7 +93,7 @@ class _BasePtForecaster_Common(_BaseObject):
                     f"Error in {cls.__name__}.get_test_params, "
                     "return must be param dict for class, or list thereof"
                 )
-            objs += [cls.get_model_cls()(**params)]
+            objs += [cls.get_cls()(**params)]
 
         num_instances = len(param_list)
         if num_instances > 1:


### PR DESCRIPTION
## Bug
[#2187](https://github.com/sktime/pytorch-forecasting/issues/2187) — `get_model_cls()` is called but never defined in `_BasePtForecaster_Common`.

## Fix
Replaced all three calls to the undefined `get_model_cls()` with `get_cls()`, which is already defined in the same class (line 15):

- Line 24: `name = cls.get_model_cls().__name__` → `name = cls.get_cls().__name__`
- Line 56: `return cls.get_model_cls()(**params)` → `return cls.get_cls()(**params)`
- Line 96: `objs += [cls.get_model_cls()(**params)]` → `objs += [cls.get_cls()(**params)]`

## Testing
Before this fix:
```python
from pytorch_forecasting.models.dlinear._dlinear_pkg_v2 import DLinear_pkg_v2
DLinear_pkg_v2.create_test_instance()
# AttributeError: type object 'DLinear_pkg_v2' has no attribute 'get_model_cls'
```

After this fix, `create_test_instance()`, `create_test_instances_and_names()`, and the `name()` fallback branch will work correctly.

Happy to address any feedback.

Greetings, saschabuehrle