### PR TITLE
[BUG] Remove outdated strict naming convention test in test_all_estim…

### DIFF
--- a/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
+++ b/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
@@ -115,14 +115,6 @@ class TestAllPtForecastersV2(EstimatorPackageConfig, EstimatorFixtureGenerator):
 
     def test_pkg_linkage(self, object_pkg, object_class):
         """Test that the package is linked correctly."""
-        # check name method
-        msg = (
-            f"Package {object_pkg}.name() does not match class "
-            f"name {object_class.__name__}. "
-            "The expected package name is "
-            f"{object_class.__name__}_pkg."
-        )
-        assert object_pkg.name() == object_class.__name__, msg
 
         # check naming convention
         class_name = object_class.__name__


### PR DESCRIPTION
Closes #2183

The strict naming convention test using `object_pkg.name()` was still present in `test_all_estimators_v2`.

This check enforced that the package name must exactly match the estimator class name. However, the naming convention tests were relaxed in #2080 to allow multiple valid naming patterns.

Because of this update, the old assertion is redundant and may incorrectly enforce the previous strict convention.

This PR removes the obsolete assertion block.