### PR TITLE
[BUG] Fix _load_config() to support .pkl file paths

### DIFF
--- a/pytorch_forecasting/base/_base_pkg.py
+++ b/pytorch_forecasting/base/_base_pkg.py
@@ -103,6 +103,10 @@ class Base_pkg(_BasePtForecasterV2):
             with open(path) as f:
                 return yaml.safe_load(f) or {}
 
+        elif suffix == ".pkl":
+            with open(path, "rb") as f:
+                return pickle.load(f)  
+
         else:
             raise ValueError(
                 f"Unsupported config format: {suffix}. Use .yaml, .yml, or .pkl"

--- a/pytorch_forecasting/base/_base_pkg.py
+++ b/pytorch_forecasting/base/_base_pkg.py
@@ -105,8 +105,7 @@ class Base_pkg(_BasePtForecasterV2):
 
         elif suffix == ".pkl":
             with open(path, "rb") as f:
-                return pickle.load(f)  
-
+                return pickle.load(f)  # noqa: S301
         else:
             raise ValueError(
                 f"Unsupported config format: {suffix}. Use .yaml, .yml, or .pkl"

--- a/pytorch_forecasting/tests/test_base_pkg.py
+++ b/pytorch_forecasting/tests/test_base_pkg.py
@@ -1,0 +1,29 @@
+"""Tests for Base_pkg._load_config."""
+
+import pickle
+import tempfile
+
+import pytest
+
+from pytorch_forecasting.base._base_pkg import Base_pkg
+
+
+def test_load_config_pkl():
+    """Test that _load_config correctly loads a .pkl file path."""
+    cfg = {"moving_avg": 25}
+    with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+        pickle.dump(cfg, f)
+        pkl_path = f.name
+
+    result = Base_pkg._load_config(pkl_path)
+    assert result == {"moving_avg": 25}
+
+
+def test_load_config_unsupported_format():
+    """Test that _load_config raises ValueError for unsupported formats."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        f.write(b"{}")
+        json_path = f.name
+
+    with pytest.raises(ValueError, match="Unsupported config format"):
+        Base_pkg._load_config(json_path)


### PR DESCRIPTION
#2189 

Reference Issues/PRs

```
Fixes #2189

```

What does this implement/fix? Explain your changes.

```
_load_config() in Base_pkg claimed .pkl support in both the docstring and 
the error message, but raised ValueError when a .pkl path was passed directly.

Added an elif branch for .pkl that opens the file in binary mode and loads 
it with pickle.load(), consistent with how .pkl files are already handled 
in the config is None branch of the same method.

Before fix:
    pkg = DLinear_pkg_v2(model_cfg="config.pkl")
    # ValueError: Unsupported config format: .pkl. Use .yaml, .yml, or .pkl

After fix:
    pkg = DLinear_pkg_v2(model_cfg="config.pkl")
    # loads correctly

Changed file: pytorch_forecasting/base/_base_pkg.py

```

What should a reviewer concentrate their feedback on?

```
- The elif suffix == ".pkl" branch added to _load_config()

```

Did you add any tests for the change?

```
Added a unit test in pytorch_forecasting/tests/test_base_pkg.py:

    def test_load_config_pkl():
        import pickle, tempfile
        from pytorch_forecasting.base._base_pkg import Base_pkg

        cfg = {"moving_avg": 25}
        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
            pickle.dump(cfg, f)
            pkl_path = f.name

        result = Base_pkg._load_config(pkl_path)
        assert result == {"moving_avg": 25}

```



PR checklist

```
- [x] The PR title starts with [BUG]
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing

```
