### PR TITLE
[DOC] Migrate samplers and KANLayer docstrings to NumPy style

### DIFF
--- a/pytorch_forecasting/data/samplers.py
+++ b/pytorch_forecasting/data/samplers.py
@@ -28,15 +28,21 @@ class GroupedSampler(Sampler):
         """
         Initialize.
 
-        Args:
-            sampler (Sampler or Iterable): Base sampler. Can be any iterable object
-            drop_last (bool): if to drop last mini-batch from a group if it is smaller than batch_size.
-                Defaults to False.
-            shuffle (bool): if to shuffle dataset. Defaults to False.
-            batch_size (int, optional): Number of samples in a mini-batch. This is rather the maximum number
-                of samples. Because mini-batches are grouped by prediction time, chances are that there
-                are multiple where batch size will be smaller than the maximum. Defaults to 64.
-        """  # noqa: E501
+        Parameters
+        ----------
+        sampler : Sampler or Iterable
+            Base sampler. Can be any iterable object.
+        drop_last : bool
+            If ``True``, drop last mini-batch from a group if it is smaller
+            than ``batch_size``. Default is ``False``.
+        shuffle : bool
+            If ``True``, shuffle dataset. Default is ``False``.
+        batch_size : int
+            Number of samples in a mini-batch. This is rather the maximum
+            number of samples. Because mini-batches are grouped by prediction
+            time, chances are that there are multiple where batch size will be
+            smaller than the maximum. Default is 64.
+        """
         # Since collections.abc.Iterable does not check for `__getitem__`, which
         # is one way for an object to be an iterable, we don't do an `isinstance`
         # check here.
@@ -65,12 +71,18 @@ class GroupedSampler(Sampler):
         """
         Create the groups which can be sampled.
 
-        Args:
-            sampler (Sampler): will have attribute data_source which is of type TimeSeriesDataSet.
+        Parameters
+        ----------
+        sampler : Sampler
+            Will have attribute ``data_source`` which is of type
+            ``TimeSeriesDataSet``.
 
-        Returns:
-            dict-like: dictionary-like object with data_source.index as values and group names as keys
-        """  # noqa: E501
+        Returns
+        -------
+        dict-like
+            Dictionary-like object with ``data_source.index`` as values and
+            group names as keys.
+        """
         raise NotImplementedError()
 
     def construct_batch_groups(self, groups):

--- a/pytorch_forecasting/layers/_kan/_kan_layer.py
+++ b/pytorch_forecasting/layers/_kan/_kan_layer.py
@@ -188,7 +188,9 @@ class KANLayer(nn.Module):
         Parameters
         ----------
         x : torch.Tensor
-            Inputs, shape (number of samples, input dimension).
+            Input tensor of shape (batch_size, in_dim), where:
+              - batch_size is the number of input samples.
+              - in_dim is the input feature dimension.
 
         Returns
         ----------

--- a/pytorch_forecasting/layers/_kan/_kan_layer.py
+++ b/pytorch_forecasting/layers/_kan/_kan_layer.py
@@ -140,23 +140,23 @@ class KANLayer(nn.Module):
 
     def forward(self, x):
         """
-        KANLayer forward given input x
+        KANLayer forward given input x.
 
         Parameters
-        -----
+        ----------
         x : torch.Tensor
             Input tensor of shape (batch_size, in_dim), where:
               - batch_size is the number of input samples.
               - in_dim is the input feature dimension.
 
         Returns
-        --------
+        ----------
         y : torch.Tensor
             Output tensor, the result of applying spline and residual
             transformations followed by weighted summation.
 
         Examples
-        --------
+        ----------
         The following is an example from the original `pykan` library, adapted here
         for illustration within the PyTorch Forecasting integration.
 
@@ -183,19 +183,19 @@ class KANLayer(nn.Module):
 
     def update_grid_from_samples(self, x):
         """
-        Update grid from samples
+        Update grid from samples.
 
         Parameters
-        -----
-        x : 2D torch.float
-            inputs, shape (number of samples, input dimension)
+        ----------
+        x : torch.Tensor
+            Inputs, shape (number of samples, input dimension).
 
-        Returns:
-        --------
+        Returns
+        ----------
         None
 
         Examples
-        -------
+        ----------
         >>> model = KANLayer(in_dim=1, out_dim=1, num=5, k=3)
         >>> print(model.grid.data)
         >>> x = torch.linspace(-3,3,steps=100)[:,None]
@@ -213,12 +213,12 @@ class KANLayer(nn.Module):
             Generate adaptive or uniform grid points from sorted input samples.
 
             Parameters
-            -----
+            ----------
             num_interval : int
                 Number of intervals between grid points.
 
-            Returns:
-            --------
+            Returns
+            ----------
             grid : torch.Tensor
                 New grid of shape (in_dim, num_interval + 1).
             """


### PR DESCRIPTION
## Summary

Migrate docstrings from Google style to NumPy style in:
- `pytorch_forecasting/data/samplers.py` — `GroupedSampler.__init__` and `GroupedSampler.get_groups`
- `pytorch_forecasting/layers/_kan/_kan_layer.py` — `KANLayer.forward`, `KANLayer.update_grid_from_samples`, and inner `get_grid`

Changes include converting `Args:`/`Returns:` sections to `Parameters`/`Returns` with proper numpydoc underlines and formatting.

Addresses #2066.

## Test plan

- [x] Pre-commit hooks pass (ruff, ruff-format, trailing-whitespace, end-of-file-fixer)
- [x] Existing V2 test suite passes (85/85)
- [x] CI passes on PR