### PR TITLE
[BUG] Fix logging_metrics not registered as submodules in v2 BaseModel (#2197)

### DIFF
--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -53,7 +53,9 @@ class BaseModel(LightningModule):
     ):
         super().__init__()
         self.loss = loss
-        self.logging_metrics = logging_metrics if logging_metrics is not None else []
+        self.logging_metrics = (
+            nn.ModuleList(logging_metrics) if logging_metrics else nn.ModuleList()
+        )
         self.optimizer = optimizer
         self.optimizer_params = optimizer_params if optimizer_params is not None else {}
         self.lr_scheduler = lr_scheduler

--- a/tests/test_models/test_dlinear_v2.py
+++ b/tests/test_models/test_dlinear_v2.py
@@ -166,3 +166,56 @@ def test_univariate_forecast():
     assert "prediction" in output
     assert output["prediction"].shape[0] == dm.batch_size
     assert output["prediction"].shape[1] == metadata["prediction_length"]
+
+
+def test_logging_metrics_is_module_list(sample_dataset):
+    """Test that logging_metrics are stored as nn.ModuleList (#2197)."""
+    dm = sample_dataset["data_module"]
+    metadata = dm.metadata
+
+    metrics = [SMAPE(), MAE()]
+    model = DLinear(
+        loss=MAE(),
+        moving_avg=5,
+        individual=False,
+        logging_metrics=metrics,
+        metadata=metadata,
+    )
+
+    assert isinstance(model.logging_metrics, nn.ModuleList)
+
+    submodule_list = list(model.modules())
+    for m in metrics:
+        assert m in submodule_list
+
+
+def test_empty_logging_metrics_is_module_list(sample_dataset):
+    """Test that empty logging_metrics is also nn.ModuleList (#2197)."""
+    dm = sample_dataset["data_module"]
+    metadata = dm.metadata
+
+    model = DLinear(loss=MAE(), moving_avg=5, individual=False, metadata=metadata)
+
+    assert isinstance(model.logging_metrics, nn.ModuleList)
+    assert len(model.logging_metrics) == 0
+
+
+def test_logging_metrics_device_propagation(sample_dataset):
+    """Test that metric state tensors follow model device moves (#2197)."""
+    dm = sample_dataset["data_module"]
+    metadata = dm.metadata
+
+    model = DLinear(
+        loss=MAE(),
+        moving_avg=5,
+        individual=False,
+        logging_metrics=[SMAPE(), MAE()],
+        metadata=metadata,
+    )
+
+    model.to("meta")
+    for metric in model.logging_metrics:
+        for state_name in metric._defaults:
+            val = getattr(metric, state_name)
+            if isinstance(val, torch.Tensor):
+                assert val.device.type == "meta"


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2197.

#### What does this implement/fix? Explain your changes.

`BaseModel.__init__()` in `_base_model_v2.py` stored `logging_metrics` as a plain Python list instead of `nn.ModuleList`. PyTorch only tracks submodules assigned as `nn.Module`, `nn.ModuleList`, or `nn.ModuleDict` attributes. Because metrics were in a plain list, they were not registered as submodules, so when `model.to("cuda")` was called, metric internal state buffers (`losses`, `lengths` registered via `add_state()`) stayed on CPU. This caused a `RuntimeError: Expected all tensors to be on the same device` during `training_step` / `validation_step` / `test_step`.

All 5 existing v2 models are affected (DLinear, TimeXer, SAMformer, TFT, TiDE).

The fix wraps `logging_metrics` in `nn.ModuleList`, matching the v1 implementation at `_base_model.py:553-558`.

#### What should a reviewer concentrate their feedback on?

- The one-line production fix in `_base_model_v2.py`
- The three regression tests, in particular whether iterating `metric._defaults` to reach torchmetrics state tensors is acceptable or if there is a cleaner public API

#### Did you add any tests for the change?

Yes, three tests appended to `tests/test_models/test_dlinear_v2.py`:

- `test_logging_metrics_is_module_list` — asserts the container type and that metrics appear in `model.modules()`
- `test_empty_logging_metrics_is_module_list` — asserts empty case also uses `nn.ModuleList`
- `test_logging_metrics_device_propagation` — moves model to `torch.device("meta")` and checks that metric state tensors follow. This catches the bug on CPU-only CI since `.to("meta")` is a real device move unlike `.to("cpu")` which is a no-op when already on CPU.

#### Any other comments?

Tests reuse the existing `sample_dataset` fixture in `test_dlinear_v2.py`.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. → [BUG]
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing