### PR TITLE
[WIP][ENH] TTM data pipeline: _dataset_class hook + TTMDataModule

### DIFF
--- a/pytorch_forecasting/data/_fm_data_module.py
+++ b/pytorch_forecasting/data/_fm_data_module.py
@@ -2,7 +2,7 @@
 Foundation model data modules for pytorch-forecasting.
 
 Provides ``TTMDataModule`` for IBM's TinyTimeMixer (TTM) and the backing
-``_TTMDataset``.  The pattern — subclassing ``TslibDataModule`` and setting
+``_TTMDataset``.  The pattern subclassing ``TslibDataModule`` and setting
 ``_dataset_class`` — is designed to be reused for other foundation models
 (Chronos, Moirai, etc.) with their own ``__getitem__`` overrides.
 """
@@ -76,7 +76,7 @@ class _TTMDataset(_TslibDataset):
         history_target = processed_data["target"][history_indices]
         future_target = processed_data["target"][future_indices]
 
-        # Continuous features: (total_len, n_cont) — targets already excluded by base
+        # Continuous features: (total_len, n_cont) targets already excluded by base
         cont_features = processed_data["features"]["continuous"]
         cont_names = self.data_module.metadata["feature_names"]["continuous"]
         cont_name_to_idx = {name: i for i, name in enumerate(cont_names)}
@@ -123,11 +123,11 @@ class _TTMDataset(_TslibDataset):
         }
 
         # Stage-aware: omit future_values during predict; include for all other stages
-        # (None is treated identically to "fit" — include future_values)
+        # (None is treated identically to "fit" and include future_values)
         if self._stage != "predict":
             x["future_values"] = future_known
 
-        # y — squeeze to (prediction_length,) for single target
+        # y, squeeze to (prediction_length,) for single target
         if self.data_module.n_targets > 1:
             y = [future_target[:, i] for i in range(self.data_module.n_targets)]
         else:
@@ -186,7 +186,7 @@ class TTMDataModule(TslibDataModule):
         n_targets = self.metadata["n_features"]["target"]
 
         # Ordering must match _TTMDataset.__getitem__ concatenation:
-        #   targets → past-only (cont_names order) → known-future (cont_names order)
+        #   targets -> past-only (cont_names order) -> known-future (cont_names order)
         past_only_cont = [n for n in cont_names if n not in known_names]
         known_future_cont = [n for n in cont_names if n in known_names]
 

--- a/pytorch_forecasting/data/_fm_data_module.py
+++ b/pytorch_forecasting/data/_fm_data_module.py
@@ -1,0 +1,238 @@
+"""
+Foundation model data modules for pytorch-forecasting.
+
+Provides ``TTMDataModule`` for IBM's TinyTimeMixer (TTM) and the backing
+``_TTMDataset``.  The pattern — subclassing ``TslibDataModule`` and setting
+``_dataset_class`` — is designed to be reused for other foundation models
+(Chronos, Moirai, etc.) with their own ``__getitem__`` overrides.
+"""
+
+from typing import Any
+
+import torch
+
+from pytorch_forecasting.data._tslib_data_module import (
+    TslibDataModule,
+    _TslibDataset,
+)
+
+
+class _TTMDataset(_TslibDataset):
+    """
+    Dataset for TinyTimeMixer (TTM) foundation model.
+
+    Overrides ``__getitem__`` to produce ``past_values``,
+    ``past_observed_mask``, and ``future_values`` in the channel layout
+    expected by TTM::
+
+        past_values: [targets | past-only covariates | known-future covariates]
+
+    Parameters
+    ----------
+    dataset : TimeSeries
+        The underlying time series dataset.
+    data_module : TTMDataModule
+        Parent data module — provides channel index metadata.
+    windows : list[tuple[int, int, int, int]]
+        Pre-computed (series_idx, start_idx, context_len, pred_len) windows.
+    add_relative_time_idx : bool, default False
+        Passed through to base class (unused by TTM).
+    """
+
+    def __init__(self, dataset, data_module, windows, add_relative_time_idx=False):
+        super().__init__(dataset, data_module, windows, add_relative_time_idx)
+        # Capture stage at construction time so that a subsequent setup() call
+        # on the data module does not retroactively change behaviour for
+        # already-instantiated datasets.
+        self._stage = getattr(data_module, "_stage", None)
+
+    def __getitem__(self, idx: int) -> tuple[dict[str, Any], Any]:
+        """
+        Return one TTM-compatible sample.
+
+        Channel ordering in ``past_values``::
+
+            [targets | past-only covariates | known-future covariates]
+
+        Both groups follow the ordering in ``metadata["feature_names"]["continuous"]``.
+        This ordering must match the index derivation in ``TTMDataModule.setup()``.
+        """
+        series_idx, start_idx, context_length, prediction_length = self.windows[idx]
+
+        # TODO: cache _preprocess_data output per index (Finding 5 from issue #2184)
+        # Plan: populate self._cache: dict[int, ...] lazily on first __getitem__ access
+        processed_data = self.data_module._preprocess_data(series_idx)
+
+        history_indices = slice(start_idx, start_idx + context_length)
+        future_indices = slice(
+            start_idx + context_length,
+            start_idx + context_length + prediction_length,
+        )
+
+        # Target: (context_length, n_targets) and (prediction_length, n_targets)
+        # Note: target is always 2D (total_len, n_targets) because TimeSeries in
+        # _timeseries_v2.py stores y as data[_target] where _target is always a list.
+        # Even for a single target, data[["target"]].to_numpy() yields shape (T, 1).
+        history_target = processed_data["target"][history_indices]
+        future_target = processed_data["target"][future_indices]
+
+        # Continuous features: (total_len, n_cont) — targets already excluded by base
+        cont_features = processed_data["features"]["continuous"]
+        cont_names = self.data_module.metadata["feature_names"]["continuous"]
+        cont_name_to_idx = {name: i for i, name in enumerate(cont_names)}
+
+        past_only_names = self.data_module._past_only_cont_names
+        known_future_names = self.data_module._known_future_cont_names
+
+        past_only_idx = [cont_name_to_idx[n] for n in past_only_names]
+        known_future_idx = [cont_name_to_idx[n] for n in known_future_names]
+
+        # Slice history window
+        history_cont = cont_features[history_indices]  # (ctx, n_cont)
+
+        # Build past_values: targets | past-only | known-future
+        parts = [history_target]
+        if past_only_idx:
+            parts.append(history_cont[:, past_only_idx])
+        if known_future_idx:
+            parts.append(history_cont[:, known_future_idx])
+
+        past_values = torch.cat(parts, dim=-1)  # (context_length, n_channels)
+
+        if past_values.ndim != 2:
+            raise ValueError(
+                f"past_values must be 2D (seq, channels), got shape {past_values.shape}"
+            )
+
+        # Per-channel observed mask: 1.0 observed, 0.0 NaN
+        past_observed_mask = (~torch.isnan(past_values)).float()
+        past_values = torch.nan_to_num(past_values, nan=0.0)
+
+        # future_values: continuous known-future covariates only (no targets)
+        future_cont = cont_features[future_indices]  # (pred, n_cont)
+        future_known = (
+            future_cont[:, known_future_idx]
+            if known_future_idx
+            else torch.zeros(prediction_length, 0)
+        )
+
+        x: dict[str, Any] = {
+            "past_values": past_values,
+            "past_observed_mask": past_observed_mask,
+            "prediction_channel_indices": self.data_module._prediction_channel_indices,
+        }
+
+        # Stage-aware: omit future_values during predict; include for all other stages
+        # (None is treated identically to "fit" — include future_values)
+        if self._stage != "predict":
+            x["future_values"] = future_known
+
+        # y — squeeze to (prediction_length,) for single target
+        if self.data_module.n_targets > 1:
+            y = [future_target[:, i] for i in range(self.data_module.n_targets)]
+        else:
+            y = future_target.squeeze(-1)
+
+        return x, y
+
+
+class TTMDataModule(TslibDataModule):
+    """
+    Data module for TinyTimeMixer (TTM) foundation model.
+
+    Subclasses ``TslibDataModule``, swapping in ``_TTMDataset`` via the
+    ``_dataset_class`` hook and providing a generic ``collate_fn`` that does
+    not hardcode key names.
+
+    Parameters
+    ----------
+    Same as ``TslibDataModule``.
+    """
+
+    _dataset_class = _TTMDataset
+
+    def setup(self, stage: str | None = None) -> None:
+        """
+        Set up datasets for fit / test / predict stages.
+
+        Stores ``_stage`` on the instance before calling ``super().setup()``
+        so that ``_TTMDataset.__init__`` can capture it at construction time.
+        Also derives ``_prediction_channel_indices`` and
+        ``_exogenous_channel_indices`` from dataset metadata.
+
+        Notes
+        -----
+        ``self.metadata`` is a lazy property backed by
+        ``self.time_series_metadata``, which is populated in ``__init__``.
+        It is therefore safe to access here before ``super().setup()`` runs.
+
+        **Repeated calls:** The ``hasattr`` idempotency guards in the base
+        ``setup()`` check ``_train_dataset`` / ``_test_dataset`` (leading
+        underscore) but assign ``train_dataset`` / ``test_dataset`` (no
+        underscore) — so the guards are permanently inactive and datasets are
+        re-created on every call.  If Lightning calls ``setup("fit")`` then
+        ``setup("predict")`` on the same instance, ``train_dataset`` will be
+        replaced by a ``_TTMDataset`` with ``_stage="predict"``, which will
+        omit ``future_values`` from training batches.  Do not iterate
+        ``train_dataloader()`` after calling ``setup("predict")`` on the same
+        instance.
+        """
+        self._stage = stage
+
+        # Derive channel indices -----------------------------------------------
+        feature_names = self.metadata["feature_names"]
+        cont_names = feature_names["continuous"]  # already excludes targets
+        known_names = set(feature_names["known"])
+        n_targets = self.metadata["n_features"]["target"]
+
+        # Ordering must match _TTMDataset.__getitem__ concatenation:
+        #   targets → past-only (cont_names order) → known-future (cont_names order)
+        past_only_cont = [n for n in cont_names if n not in known_names]
+        known_future_cont = [n for n in cont_names if n in known_names]
+
+        # Indices into past_values (NOT into the raw feature array)
+        self._prediction_channel_indices = list(range(n_targets))
+        self._exogenous_channel_indices = list(
+            range(n_targets, n_targets + len(past_only_cont) + len(known_future_cont))
+        )
+        # Stash name lists so __getitem__ can build the concat in the same order
+        self._past_only_cont_names = past_only_cont
+        self._known_future_cont_names = known_future_cont
+
+        super().setup(stage)
+
+    @staticmethod
+    def collate_fn(batch):
+        """
+        Generic collate function for TTM batches.
+
+        All ``torch.Tensor``-valued keys are stacked into ``(batch, ...)``
+        tensors.  Non-Tensor keys (e.g. ``prediction_channel_indices``) are
+        deduplicated to a single value — they are dataset-level constants
+        identical across every sample in a batch.
+
+        .. warning::
+            The non-Tensor deduplication (taking ``batch[0][0][k]``) is
+            correct **only** for dataset-level constants.  Do NOT add
+            per-sample non-Tensor values to the ``x`` dict without revisiting
+            this logic — they would be silently dropped for all but the first
+            sample.
+        """
+        x_keys = batch[0][0].keys()
+        x_batch = {}
+        for k in x_keys:
+            sample_val = batch[0][0][k]
+            if isinstance(sample_val, torch.Tensor):
+                x_batch[k] = torch.stack([x[k] for x, _ in batch])
+            else:
+                x_batch[k] = sample_val
+
+        if isinstance(batch[0][1], list | tuple):
+            num_targets = len(batch[0][1])
+            y_batch = [
+                torch.stack([s[i] for _, s in batch]) for i in range(num_targets)
+            ]
+        else:
+            y_batch = torch.stack([y for _, y in batch])
+
+        return x_batch, y_batch

--- a/pytorch_forecasting/data/_tslib_data_module.py
+++ b/pytorch_forecasting/data/_tslib_data_module.py
@@ -287,6 +287,8 @@ class TslibDataModule(LightningDataModule):
         Custom collate function for the dataloader.
     """  # noqa: E501
 
+    _dataset_class = _TslibDataset  # subclasses override to use a custom dataset
+
     def __init__(
         self,
         time_series_dataset: TimeSeries,
@@ -724,14 +726,14 @@ class TslibDataModule(LightningDataModule):
                 self._train_windows = self._create_windows(self._train_indices)
                 self._val_windows = self._create_windows(self._val_indices)
 
-                self.train_dataset = _TslibDataset(
+                self.train_dataset = self._dataset_class(
                     dataset=self.time_series_dataset,
                     data_module=self,
                     windows=self._train_windows,
                     add_relative_time_idx=self.add_relative_time_idx,
                 )
 
-                self.val_dataset = _TslibDataset(
+                self.val_dataset = self._dataset_class(
                     dataset=self.time_series_dataset,
                     data_module=self,
                     windows=self._val_windows,
@@ -741,7 +743,7 @@ class TslibDataModule(LightningDataModule):
             if not hasattr(self, "_test_dataset"):
                 self._test_windows = self._create_windows(self._test_indices)
 
-                self.test_dataset = _TslibDataset(
+                self.test_dataset = self._dataset_class(
                     dataset=self.time_series_dataset,
                     data_module=self,
                     windows=self._test_windows,
@@ -752,7 +754,7 @@ class TslibDataModule(LightningDataModule):
             predict_indices = torch.arange(len(self.time_series_dataset))
             self._predict_windows = self._create_windows(predict_indices)
 
-            self.predict_dataset = _TslibDataset(
+            self.predict_dataset = self._dataset_class(
                 dataset=self.time_series_dataset,
                 data_module=self,
                 windows=self._predict_windows,

--- a/pytorch_forecasting/data/tests/test_fm_data_module.py
+++ b/pytorch_forecasting/data/tests/test_fm_data_module.py
@@ -65,7 +65,7 @@ def ttm_dm(fm_timeseries):
 
 
 # ---------------------------------------------------------------------------
-# Task 2 tests — skeleton wiring
+# Task 2 tests:- skeleton wiring
 # ---------------------------------------------------------------------------
 
 
@@ -77,7 +77,7 @@ def test_ttm_data_module_uses_ttm_dataset(ttm_dm):
     assert isinstance(ttm_dm.train_dataset, _TTMDataset)
     assert isinstance(ttm_dm.val_dataset, _TTMDataset)
 
-    # Also verify predict stage — uses a fresh ttm_dm (function-scoped fixture)
+    # Also verify predict stage uses a fresh ttm_dm (function-scoped fixture)
     # so calling setup("predict") here is safe and does not affect other tests.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -98,7 +98,7 @@ def test_channel_indices_derived(ttm_dm):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         ttm_dm.setup("fit")
-    # 1 target → prediction channels at index 0
+    # 1 target -> prediction channels at index 0
     assert ttm_dm._prediction_channel_indices == [0]
     # 2 non-target continuous channels at indices 1 and 2 in past_values
     # (index 0 = target, 1 = feature_2 past-only, 2 = feature_1 known-future)
@@ -106,7 +106,7 @@ def test_channel_indices_derived(ttm_dm):
 
 
 # ---------------------------------------------------------------------------
-# Task 3 tests — __getitem__ shapes and stage gating
+# Task 3 tests:- __getitem__ shapes and stage gating
 # ---------------------------------------------------------------------------
 
 
@@ -123,13 +123,13 @@ def test_batch_shapes(ttm_dm):
     # Fixture: 1 target + 1 past-only + 1 known-future = 3 channels
     assert x["past_values"].shape == (B, ctx, 3)
     assert x["past_observed_mask"].shape == (B, ctx, 3)
-    # Fixture has no NaN values — every position must be observed (all 1.0)
+    # Fixture has no NaN values, every position must be observed (all 1.0)
     assert x["past_observed_mask"].bool().all()
     # future_values: 1 known-future continuous covariate
     assert x["future_values"].shape == (B, pred, 1)
     # prediction_channel_indices: single list[int] after collate dedup
     assert x["prediction_channel_indices"] == [0]
-    # y: single target → 1-D per sample → (B, pred) after stack
+    # y: single target -> 1-D per sample -> (B, pred) after stack
     assert y.shape == (B, pred)
 
 
@@ -143,7 +143,7 @@ def test_no_future_values_in_predict(ttm_dm):
 
 
 # ---------------------------------------------------------------------------
-# Task 4 test — end-to-end forward pass with MockTTM
+# Task 4 test:- end-to-end forward pass with MockTTM
 # ---------------------------------------------------------------------------
 
 
@@ -151,7 +151,7 @@ def test_mock_ttm_forward(ttm_dm):
     """
     A minimal mock model can consume a TTMDataModule batch without error.
 
-    No tsfm_public import — MockTTM is a stand-in for the real TTM forward
+    No tsfm_public import as MockTTM is a stand-in for the real TTM forward
     signature: forward(past_values, past_observed_mask=None, **kwargs).
     """
     pred_len = ttm_dm.prediction_length  # bound from fixture

--- a/pytorch_forecasting/data/tests/test_fm_data_module.py
+++ b/pytorch_forecasting/data/tests/test_fm_data_module.py
@@ -1,0 +1,182 @@
+"""Tests for foundation model data modules (_fm_data_module.py)."""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+import torch.nn as nn
+
+from pytorch_forecasting.data._fm_data_module import TTMDataModule, _TTMDataset
+from pytorch_forecasting.data.timeseries import TimeSeries
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def fm_timeseries():
+    """TimeSeries with 1 target, 1 past-only covariate, 1 known-future covariate."""
+    np.random.seed(0)
+    n_series, n_timesteps = 20, 50
+    rows = []
+    for sid in range(n_series):
+        for t in range(n_timesteps):
+            rows.append(
+                {
+                    "series_id": sid,
+                    "time_idx": t,
+                    "target": np.sin(t / 5.0) + np.random.randn() * 0.1,
+                    "feature_1": np.random.randn(),  # known-future continuous
+                    "feature_2": np.random.randn(),  # past-only continuous
+                }
+            )
+    df = pd.DataFrame(rows)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ts = TimeSeries(
+            data=df,
+            time="time_idx",
+            target="target",
+            group=["series_id"],
+            num=["feature_1", "feature_2"],
+            cat=[],
+            known=["feature_1"],  # feature_1: known-future
+            unknown=["feature_2"],  # feature_2: past-only
+        )
+    return ts
+
+
+@pytest.fixture
+def ttm_dm(fm_timeseries):
+    """TTMDataModule fixture with small context/prediction lengths."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dm = TTMDataModule(
+            time_series_dataset=fm_timeseries,
+            context_length=8,
+            prediction_length=4,
+            batch_size=4,
+            num_workers=0,
+        )
+    return dm
+
+
+# ---------------------------------------------------------------------------
+# Task 2 tests — skeleton wiring
+# ---------------------------------------------------------------------------
+
+
+def test_ttm_data_module_uses_ttm_dataset(ttm_dm):
+    """TTMDataModule.setup() instantiates _TTMDataset for fit and predict stages."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ttm_dm.setup("fit")
+    assert isinstance(ttm_dm.train_dataset, _TTMDataset)
+    assert isinstance(ttm_dm.val_dataset, _TTMDataset)
+
+    # Also verify predict stage — uses a fresh ttm_dm (function-scoped fixture)
+    # so calling setup("predict") here is safe and does not affect other tests.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ttm_dm.setup("predict")
+    assert isinstance(ttm_dm.predict_dataset, _TTMDataset)
+
+
+def test_ttm_dataset_captures_stage(ttm_dm):
+    """_TTMDataset stores the stage at construction time."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ttm_dm.setup("fit")
+    assert ttm_dm.train_dataset._stage == "fit"
+
+
+def test_channel_indices_derived(ttm_dm):
+    """TTMDataModule.setup() derives prediction/exogenous channel indices."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ttm_dm.setup("fit")
+    # 1 target → prediction channels at index 0
+    assert ttm_dm._prediction_channel_indices == [0]
+    # 2 non-target continuous channels at indices 1 and 2 in past_values
+    # (index 0 = target, 1 = feature_2 past-only, 2 = feature_1 known-future)
+    assert ttm_dm._exogenous_channel_indices == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Task 3 tests — __getitem__ shapes and stage gating
+# ---------------------------------------------------------------------------
+
+
+def test_batch_shapes(ttm_dm):
+    """past_values, past_observed_mask, and future_values have correct shapes."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ttm_dm.setup("fit")
+    x, y = next(iter(ttm_dm.train_dataloader()))
+
+    B = ttm_dm.batch_size
+    ctx = ttm_dm.context_length  # 8
+    pred = ttm_dm.prediction_length  # 4
+    # Fixture: 1 target + 1 past-only + 1 known-future = 3 channels
+    assert x["past_values"].shape == (B, ctx, 3)
+    assert x["past_observed_mask"].shape == (B, ctx, 3)
+    # Fixture has no NaN values — every position must be observed (all 1.0)
+    assert x["past_observed_mask"].bool().all()
+    # future_values: 1 known-future continuous covariate
+    assert x["future_values"].shape == (B, pred, 1)
+    # prediction_channel_indices: single list[int] after collate dedup
+    assert x["prediction_channel_indices"] == [0]
+    # y: single target → 1-D per sample → (B, pred) after stack
+    assert y.shape == (B, pred)
+
+
+def test_no_future_values_in_predict(ttm_dm):
+    """future_values must not appear in x during the predict stage."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ttm_dm.setup("predict")
+    x, _ = next(iter(ttm_dm.predict_dataloader()))
+    assert "future_values" not in x
+
+
+# ---------------------------------------------------------------------------
+# Task 4 test — end-to-end forward pass with MockTTM
+# ---------------------------------------------------------------------------
+
+
+def test_mock_ttm_forward(ttm_dm):
+    """
+    A minimal mock model can consume a TTMDataModule batch without error.
+
+    No tsfm_public import — MockTTM is a stand-in for the real TTM forward
+    signature: forward(past_values, past_observed_mask=None, **kwargs).
+    """
+    pred_len = ttm_dm.prediction_length  # bound from fixture
+
+    class MockTTM(nn.Module):
+        def __init__(self, prediction_length):
+            super().__init__()
+            self._pred_len = prediction_length
+
+        def forward(self, past_values, past_observed_mask=None, **kwargs):
+            B, T, C = past_values.shape
+            return {"prediction_outputs": torch.zeros(B, self._pred_len, 1)}
+
+    model = MockTTM(pred_len)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ttm_dm.setup("fit")
+
+    x, _ = next(iter(ttm_dm.train_dataloader()))
+
+    out = model(
+        x["past_values"],
+        past_observed_mask=x["past_observed_mask"],
+    )
+
+    B = x["past_values"].shape[0]
+    assert out["prediction_outputs"].shape == (B, pred_len, 1)

--- a/pytorch_forecasting/data/tests/test_tslib_data_module.py
+++ b/pytorch_forecasting/data/tests/test_tslib_data_module.py
@@ -530,3 +530,37 @@ def test_multivariate_target():
     assert (
         y.shape[-1] == 2
     ), "Target should have two dimensions for n_features for multivariate target."
+
+
+def test_dataset_class_hook(sample_timeseries_data):
+    """TslibDataModule._dataset_class is used for all four dataset instantiations."""
+    import warnings
+
+    from pytorch_forecasting.data._tslib_data_module import _TslibDataset
+
+    class _DummyDataset(_TslibDataset):
+        pass
+
+    class _DummyDataModule(TslibDataModule):
+        _dataset_class = _DummyDataset
+
+    dm = _DummyDataModule(
+        time_series_dataset=sample_timeseries_data,
+        context_length=8,
+        prediction_length=4,
+        batch_size=2,
+        num_workers=0,
+    )
+    # sample_timeseries_data is session-scoped; nothing here mutates it.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dm.setup("fit")
+    assert isinstance(dm.train_dataset, _DummyDataset)
+    assert isinstance(dm.val_dataset, _DummyDataset)
+
+    # Verify test and predict stages also use the subclass
+    dm.setup("test")
+    assert isinstance(dm.test_dataset, _DummyDataset)
+
+    dm.setup("predict")
+    assert isinstance(dm.predict_dataset, _DummyDataset)


### PR DESCRIPTION
#### Reference Issues/PRs
WIP towards #2184.  Related: #1959 #2051

#### What does this implement/fix? Explain your changes.

WIP draft for #2184, that is integrating IBM's TinyTimeMixer (TTM) into pytorch-forecasting's v2 pipeline. 
TTM is a pretrained foundation model for zero-shot and fine-tuned time series forecasting, and it expects a specific input format that our current v2 pipeline doesn't produce.

This draft/WIP PR covers the data layer only. No model weights, no `tsfm_public` dependency yet, as the main aim of it was to just getting the pipeline to speak TTM's language.

&ensp;

#### Issues I ran into

`TslibDataModule.setup()` had four hardcoded `_TslibDataset(...)` calls. 
So there was no clean way to swap in a different dataset class without duplicating the entire method.

&ensp;

#### Changes made

Added `_dataset_class = _TslibDataset` to TslibDataModule and replaced those four calls with `self._dataset_class(...)`. 
Which gives a zero behavioral change for existing code.

On top of that hook:

- _TTMDataset  now overrides `__getitem__` to produce TTM-format batches:
  past_values, past_observed_mask, future_values, prediction_channel_indices
- TTMDataModule now sets _dataset_class = _TTMDataset, derives channel indices
  from metadata, and provides a `collate_fn` for the mixed Tensor/non-Tensor batch

So the channel ordering follows TTM's spec:
`[targets | past-only covariates | known-future covariates]`

&ensp;

#### Does it work?

Yes, with a `MockTTM` standing in for the real model:

```
test_ttm_data_module_uses_ttm_dataset  PASSED
test_ttm_dataset_captures_stage        PASSED
test_channel_indices_derived           PASSED
test_batch_shapes                      PASSED
test_no_future_values_in_predict       PASSED
test_mock_ttm_forward                  PASSED
```

One pre-existing failure in test_multivariate_target ('list' object has no attribute 'shape') which was reproducible on `main`, so unrelated to this PR and the changes made by it, worth a separate issue if not already tracked?

&ensp;

#### What's left

- **Caching**: `_preprocess_data` runs per `__getitem__`  so it needs a per-series cache before this is usable at scale (I mentioned it as a TODO in the code and using a short term fix for current scope)
- **Model wrapper**: thin wrapper around `tsfm_public.models.tinytimemixer`, as an optional dependency.
- **Training glue**: loss, forward, predict steps wired through `TslibBaseModel`

&ensp;

The _dataset_class hook is intentionally generic, with TTMDataModule as the first user, but the same pattern should work for Chronos, Moirai, and others with their own `__getitem__` overrides.
More discussion and testing is needed for that I believe, but initial findings seem promising.

Looking for early feedback on this hook design and TTM channel format assumptions before going further, thanks!
@phoeenniixx @PranavBhatP @agobbifbk