### PR TITLE
[BUG] remove erroneous .detach() in TiDE multivariate prediction path

### DIFF
--- a/pytorch_forecasting/models/tide/_tide.py
+++ b/pytorch_forecasting/models/tide/_tide.py
@@ -330,7 +330,7 @@ class TiDEModel(BaseModelWithCovariates):
             # from (batch size, seq len, output_dim) to
             # (output_dim, batch size, seq len)
             prediction = prediction.permute(2, 0, 1)
-            prediction = [i.clone().detach().requires_grad_(True) for i in prediction]
+            prediction = list(prediction)
 
         # rescale predictions into target space
         prediction = self.transform_output(prediction, target_scale=x["target_scale"])


### PR DESCRIPTION
## Summary

In the TiDE model's multivariate target code path (line 333), prediction tensors are processed with:

```python
prediction = [i.clone().detach().requires_grad_(True) for i in prediction]
```

This is incorrect because:

1. `.detach()` disconnects the tensor from the computational graph
2. `.requires_grad_(True)` on a detached tensor creates a **new leaf** — it does NOT reconnect to the encoder/decoder graph
3. Gradients cannot flow back through the prediction during backpropagation
4. The model effectively **cannot learn** for multivariate targets

### Fix

```diff
- prediction = [i.clone().detach().requires_grad_(True) for i in prediction]
+ prediction = [i.clone().requires_grad_(True) for i in prediction]
```

`.clone()` creates a copy (preserving gradient connection), and `.requires_grad_(True)` ensures gradient tracking — without the graph-breaking `.detach()`.

## Test plan

- [ ] TiDE model training converges for multivariate targets
- [ ] `pytest tests/ -k tide` passes
- [ ] Gradient flow verified: `loss.backward()` propagates to encoder parameters