### PR TITLE
[BUG] Add metadata validation in Samformer initialization

### DIFF
--- a/pytorch_forecasting/models/samformer/_samformer_v2.py
+++ b/pytorch_forecasting/models/samformer/_samformer_v2.py
@@ -24,10 +24,10 @@ class Samformer(BaseModel):
     ----------
     out_channels : int, optional
         Number of variables to be predicted. Default is 1.
-    hidden_size : int
-        First embedding size of the model ('r' in the paper).
-    use_revin : bool
-        Whether to use Reverse Instance Normalization.
+    hidden_size : int, optional
+        First embedding size of the model ('r' in the paper). Default is 512.
+    use_revin : bool, optional
+        Whether to use Reverse Instance Normalization. Default is True.
     metadata : dict
         Required dictionary containing sequence configuration. Must include:
         - 'max_encoder_length' (int): Maximum length of the input sequence.

--- a/pytorch_forecasting/models/samformer/_samformer_v2.py
+++ b/pytorch_forecasting/models/samformer/_samformer_v2.py
@@ -69,9 +69,7 @@ class Samformer(BaseModel):
 
         self.save_hyperparameters(ignore=["loss", "logging_metrics", "optimizer"])
         if metadata is None:
-            raise ValueError(
-                "Samformer requires 'metadata' dictionary to be provided."
-            )
+            raise ValueError("Samformer requires 'metadata' dictionary to be provided.")
         self.metadata = metadata
         self.n_quantiles = 1
 

--- a/pytorch_forecasting/models/samformer/_samformer_v2.py
+++ b/pytorch_forecasting/models/samformer/_samformer_v2.py
@@ -24,10 +24,15 @@ class Samformer(BaseModel):
     ----------
     out_channels : int, optional
         Number of variables to be predicted. Default is 1.
-    hidden_size : int, optional
-        First embedding size of the model ('r' in the paper). Default is 512.
-    use_revin : bool, optional
-        Whether to use Reverse Instance Normalization. Default is True.
+    hidden_size : int
+        First embedding size of the model ('r' in the paper).
+    use_revin : bool
+        Whether to use Reverse Instance Normalization.
+    metadata : dict
+        Required dictionary containing sequence configuration. Must include:
+        - 'max_encoder_length' (int): Maximum length of the input sequence.
+        - 'max_prediction_length' (int): Maximum length of the prediction sequence.
+        - 'encoder_cont' (int): Number of continuous variables in the encoder.
     persistence_weight : float, optional
         Weight for persistence baseline. Default is 0.0.
     """

--- a/pytorch_forecasting/models/samformer/_samformer_v2.py
+++ b/pytorch_forecasting/models/samformer/_samformer_v2.py
@@ -68,6 +68,10 @@ class Samformer(BaseModel):
         )
 
         self.save_hyperparameters(ignore=["loss", "logging_metrics", "optimizer"])
+        if metadata is None:
+            raise ValueError(
+                "Samformer requires 'metadata' dictionary to be provided."
+            )
         self.metadata = metadata
         self.n_quantiles = 1
 

--- a/tests/models/test_samformer.py
+++ b/tests/models/test_samformer.py
@@ -1,0 +1,10 @@
+import pytest
+import torch.nn as nn
+
+from pytorch_forecasting.models.samformer._samformer_v2 import Samformer
+
+
+def test_samformer_metadata_validation():
+    """Verify that Samformer raises ValueError when initialized with metadata=None."""
+    with pytest.raises(ValueError, match="Samformer requires 'metadata' dictionary"):
+        Samformer(loss=nn.MSELoss(), hidden_size=512, use_revin=True, metadata=None)


### PR DESCRIPTION
This PR addresses Issue #2212 where the `Samformer` model crashes upon initialization if `metadata` is `None`.

### Changes Made:
- Added a `ValueError` validation check in `__init__` for the `Samformer` model to immediately raise an appropriate error message if `metadata` falls back to `None`.
- Formatted code to adhere to `ruff` 88 character line-length limits.

All local tests and linters pass successfully.