### PR TITLE
Fix: correct attribute names in TslibDataModule.setup() re-entrancy guard

### DIFF
--- a/pytorch_forecasting/data/_tslib_data_module.py
+++ b/pytorch_forecasting/data/_tslib_data_module.py
@@ -691,8 +691,7 @@ class TslibDataModule(LightningDataModule):
 
         if total_series == 0:
             raise ValueError(
-                "The time series dataset is empty. "
-                "Please provide a non-empty dataset."
+                "The time series dataset is empty. Please provide a non-empty dataset."
             )
 
         # this is a very rudimentary way to handle the splits when
@@ -720,7 +719,7 @@ class TslibDataModule(LightningDataModule):
             ]
 
         if stage == "fit" or stage is None:
-            if not hasattr(self, "_train_dataset") or not hasattr(self, "_val_dataset"):
+            if not hasattr(self, "train_dataset") or not hasattr(self, "val_dataset"):
                 self._train_windows = self._create_windows(self._train_indices)
                 self._val_windows = self._create_windows(self._val_indices)
 

--- a/tests/test_data/test_tslib_data_module.py
+++ b/tests/test_data/test_tslib_data_module.py
@@ -1,0 +1,76 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pytorch_forecasting.data import TimeSeries
+from pytorch_forecasting.data._tslib_data_module import TslibDataModule
+
+
+@pytest.fixture
+def sample_tslib_dataset():
+    """Create a minimal dataset for TslibDataModule tests."""
+    n_samples = 50
+    n_series = 3
+
+    series_data = []
+    for i in range(n_series):
+        time_idx = np.arange(n_samples)
+        values = np.sin(2 * np.pi * time_idx / 20) + np.random.normal(0, 0.1, n_samples)
+        series = pd.DataFrame(
+            {
+                "time_idx": time_idx,
+                "series_id": i,
+                "value": values,
+                "feat1": np.random.normal(0, 1, n_samples),
+            }
+        )
+        series_data.append(series)
+
+    data = pd.concat(series_data).reset_index(drop=True)
+
+    ts = TimeSeries(
+        data,
+        time="time_idx",
+        group=["series_id"],
+        target=["value"],
+        num=["feat1"],
+        known=["time_idx"],
+        unknown=["value", "feat1"],
+    )
+
+    return ts
+
+
+def test_setup_reentrant_guard(sample_tslib_dataset):
+    """Regression test for issue #2218.
+
+    Verifies that calling setup('fit') a second time does NOT rebuild the
+    train and val datasets from scratch. The guard on line 723 must check the
+    correct attribute names ('train_dataset' / 'val_dataset') so that it
+    detects previously created datasets and skips re-creation.
+    """
+    dm = TslibDataModule(
+        sample_tslib_dataset,
+        context_length=16,
+        prediction_length=4,
+        batch_size=4,
+    )
+
+    dm.setup("fit")
+
+    # Capture the dataset objects created on the first call
+    train_dataset_first = dm.train_dataset
+    val_dataset_first = dm.val_dataset
+
+    # A second call to setup("fit") must hit the guard and return without
+    # recreating the datasets (i.e. the same objects should be returned).
+    dm.setup("fit")
+
+    assert dm.train_dataset is train_dataset_first, (
+        "setup('fit') must not recreate train_dataset when it already exists. "
+        "Check that the hasattr guard uses 'train_dataset', not '_train_dataset'."
+    )
+    assert dm.val_dataset is val_dataset_first, (
+        "setup('fit') must not recreate val_dataset when it already exists. "
+        "Check that the hasattr guard uses 'val_dataset', not '_val_dataset'."
+    )


### PR DESCRIPTION
Fixes #2218

## Summary

`TslibDataModule.setup()` contains a guard that is meant to skip dataset creation when `setup("fit")` is called more than once. However, the guard was checking for attributes named `_train_dataset` and `_val_dataset` (with a leading underscore), which are never assigned anywhere. The actual attributes set on the instance are `train_dataset` and `val_dataset`. This meant the guard never triggered, causing `_create_windows()` and the full dataset rebuild to run unconditionally on every `setup()` call.

## Changes

**`pytorch_forecasting/data/_tslib_data_module.py`**

Corrected the attribute names in the `hasattr` guard (line 723):

```python
# Before
if not hasattr(self, "_train_dataset") or not hasattr(self, "_val_dataset"):

# After
if not hasattr(self, "train_dataset") or not hasattr(self, "val_dataset"):
```

**`tests/test_data/test_tslib_data_module.py`** *(new file)*

Added a regression test `test_setup_reentrant_guard` that calls `setup("fit")` twice and asserts that the second call returns the same dataset objects (i.e., no rebuild occurred).

## Why this matters

- Without this fix, every `setup("fit")` call silently re-runs `torch.randperm()` and recreates all windows, leading to non-deterministic train/val/test splits across calls.
- The fix is a single-character-level change that corrects the attribute name to match what is actually set on the instance.

## Testing

All existing tests pass. A new regression test has been added to confirm the guard works as expected after this fix.
