### PR TITLE
[BUG] Move prediction tensors to CPU between batches in PredictCallback

### DIFF
--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -1,12 +1,10 @@
 from typing import Any, Optional
 from warnings import warn
 
-
 from lightning import Trainer
 from lightning.pytorch import LightningModule
 from lightning.pytorch.callbacks import BasePredictionWriter
 import torch
-
 
 
 class PredictCallback(BasePredictionWriter):
@@ -30,7 +28,6 @@ class PredictCallback(BasePredictionWriter):
         Additional keyword arguments for `to_prediction` or `to_quantiles`.
     """
 
-
     def __init__(
         self,
         mode: str = "prediction",
@@ -43,14 +40,12 @@ class PredictCallback(BasePredictionWriter):
         self.mode_kwargs = mode_kwargs or {}
         self._reset_data()
 
-
     def _reset_data(self, result: bool = True):
         """Clear collected data for a new prediction run."""
         self.predictions = []
         self.info = {key: [] for key in self.return_info}
         if result:
             self._result = None
-
 
     @staticmethod
     def _move_to_cpu(obj):
@@ -73,7 +68,6 @@ class PredictCallback(BasePredictionWriter):
             return type(obj)(PredictCallback._move_to_cpu(v) for v in obj)
         return obj
 
-
     def on_predict_batch_end(
         self,
         trainer: Trainer,
@@ -86,7 +80,6 @@ class PredictCallback(BasePredictionWriter):
         """Process and store predictions for a single batch."""
         x, y = batch
 
-
         if self.mode == "raw":
             processed_output = outputs
         elif self.mode == "prediction":
@@ -96,9 +89,7 @@ class PredictCallback(BasePredictionWriter):
         else:
             raise ValueError(f"Invalid prediction mode: {self.mode}")
 
-
         self.predictions.append(self._move_to_cpu(processed_output))
-
 
         for key in self.return_info:
             if key == "x":
@@ -112,7 +103,6 @@ class PredictCallback(BasePredictionWriter):
             else:
                 warn(f"Unknown return_info key: {key}")
 
-
     def on_predict_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
         """Collate all batch results into final tensors."""
         if self.mode == "raw" and isinstance(self.predictions[0], dict):
@@ -123,9 +113,7 @@ class PredictCallback(BasePredictionWriter):
         else:
             collated_preds = {"prediction": torch.cat(self.predictions)}
 
-
         final_result = collated_preds
-
 
         for key, data_list in self.info.items():
             if isinstance(data_list[0], dict):
@@ -136,10 +124,8 @@ class PredictCallback(BasePredictionWriter):
                 collated_info = torch.cat(data_list)
             final_result[key] = collated_info
 
-
         self._result = final_result
         self._reset_data(result=False)
-
 
     @property
     def result(self) -> dict[str, torch.Tensor]:

--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -1,20 +1,24 @@
 from typing import Any, Optional
 from warnings import warn
 
+
 from lightning import Trainer
 from lightning.pytorch import LightningModule
 from lightning.pytorch.callbacks import BasePredictionWriter
 import torch
 
 
+
 class PredictCallback(BasePredictionWriter):
     """
     Callback to capture predictions and related information internally.
+
 
     This callback is used by ``BaseModel.predict()`` to process raw model outputs
     into the desired format (``prediction``, ``quantiles``, or ``raw``) and collect
     any additional requested info (``x``, ``y``, ``index``, etc.). The results are
     collated and stored in memory, accessible via the ``.result`` property.
+
 
     Parameters
     ----------
@@ -25,6 +29,7 @@ class PredictCallback(BasePredictionWriter):
     **kwargs :
         Additional keyword arguments for `to_prediction` or `to_quantiles`.
     """
+
 
     def __init__(
         self,
@@ -38,12 +43,36 @@ class PredictCallback(BasePredictionWriter):
         self.mode_kwargs = mode_kwargs or {}
         self._reset_data()
 
+
     def _reset_data(self, result: bool = True):
         """Clear collected data for a new prediction run."""
         self.predictions = []
         self.info = {key: [] for key in self.return_info}
         if result:
             self._result = None
+
+
+    @staticmethod
+    def _move_to_cpu(obj):
+        """Recursively move tensors to CPU and detach from computation graph.
+
+        Parameters
+        ----------
+        obj : torch.Tensor, dict, list, tuple, or other
+            Object containing tensors to move to CPU.
+
+        Returns
+        -------
+        Same structure with all tensors detached and moved to CPU.
+        """
+        if isinstance(obj, torch.Tensor):
+            return obj.detach().cpu()
+        elif isinstance(obj, dict):
+            return {k: PredictCallback._move_to_cpu(v) for k, v in obj.items()}
+        elif isinstance(obj, (list, tuple)):
+            return type(obj)(PredictCallback._move_to_cpu(v) for v in obj)
+        return obj
+
 
     def on_predict_batch_end(
         self,
@@ -57,6 +86,7 @@ class PredictCallback(BasePredictionWriter):
         """Process and store predictions for a single batch."""
         x, y = batch
 
+
         if self.mode == "raw":
             processed_output = outputs
         elif self.mode == "prediction":
@@ -66,19 +96,22 @@ class PredictCallback(BasePredictionWriter):
         else:
             raise ValueError(f"Invalid prediction mode: {self.mode}")
 
-        self.predictions.append(processed_output)
+
+        self.predictions.append(self._move_to_cpu(processed_output))
+
 
         for key in self.return_info:
             if key == "x":
-                self.info[key].append(x)
+                self.info[key].append(self._move_to_cpu(x))
             elif key == "y":
-                self.info[key].append(y[0])
+                self.info[key].append(self._move_to_cpu(y[0]))
             elif key == "index":
-                self.info[key].append(y[1])
+                self.info[key].append(self._move_to_cpu(y[1]))
             elif key == "decoder_lengths":
-                self.info[key].append(x["decoder_lengths"])
+                self.info[key].append(self._move_to_cpu(x["decoder_lengths"]))
             else:
                 warn(f"Unknown return_info key: {key}")
+
 
     def on_predict_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
         """Collate all batch results into final tensors."""
@@ -90,7 +123,9 @@ class PredictCallback(BasePredictionWriter):
         else:
             collated_preds = {"prediction": torch.cat(self.predictions)}
 
+
         final_result = collated_preds
+
 
         for key, data_list in self.info.items():
             if isinstance(data_list[0], dict):
@@ -101,8 +136,10 @@ class PredictCallback(BasePredictionWriter):
                 collated_info = torch.cat(data_list)
             final_result[key] = collated_info
 
+
         self._result = final_result
         self._reset_data(result=False)
+
 
     @property
     def result(self) -> dict[str, torch.Tensor]:


### PR DESCRIPTION
Fixes #2224

## Problem
`PredictCallback.on_predict_batch_end` collects batch outputs into
`self.predictions` and `self.info` without moving tensors off the GPU.
Every tensor stays pinned in VRAM until `on_predict_epoch_end`, causing
linear VRAM accumulation across batches.

The v1 base model had an explicit guard:
```python
out = move_to_device(detach(out), "cpu")
x   = move_to_device(detach(x),   "cpu")
```

This pattern was not carried over into the v2 PredictCallback.

Fix
Added a recursive _move_to_cpu static method that handles tensors,
dicts (like x which contains mixed tensor/non-tensor values),
lists, and tuples.

Applied _move_to_cpu to all appends in on_predict_batch_end:
predictions, x, y, index, and decoder_lengths.

No changes needed in on_predict_epoch_end since tensors are
already on CPU by the time collation runs.

Testing
Validated against the reproduction script from #2224.
After fix: cb.predictions[0].device returns cpu and VRAM stays
at ~0 MB between batches.

cc @phoeenniixx @fnhirwa @PranavBhatP 