### PR TITLE
[BUG] Move prediction tensors to CPU between batches in PredictCallback

### DIFF
--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -6,6 +6,8 @@ from lightning.pytorch import LightningModule
 from lightning.pytorch.callbacks import BasePredictionWriter
 import torch
 
+from pytorch_forecasting.utils import detach, move_to_device
+
 
 class PredictCallback(BasePredictionWriter):
     """
@@ -66,17 +68,20 @@ class PredictCallback(BasePredictionWriter):
         else:
             raise ValueError(f"Invalid prediction mode: {self.mode}")
 
-        self.predictions.append(processed_output)
+        self.predictions.append(move_to_device(detach(processed_output), "cpu"))
+
+        # detach(x) copies the dict; move_to_device won't mutate the original batch
+        x_cpu = move_to_device(detach(x), "cpu")
 
         for key in self.return_info:
             if key == "x":
-                self.info[key].append(x)
+                self.info[key].append(x_cpu)
             elif key == "y":
-                self.info[key].append(y[0])
+                self.info[key].append(move_to_device(detach(y[0]), "cpu"))
             elif key == "index":
-                self.info[key].append(y[1])
+                self.info[key].append(move_to_device(detach(y[1]), "cpu"))
             elif key == "decoder_lengths":
-                self.info[key].append(x["decoder_lengths"])
+                self.info[key].append(x_cpu["decoder_lengths"])
             else:
                 warn(f"Unknown return_info key: {key}")
 

--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -70,16 +70,19 @@ class PredictCallback(BasePredictionWriter):
 
         self.predictions.append(move_to_device(detach(processed_output), "cpu"))
 
-        # detach(x) copies the dict; move_to_device won't mutate the original batch
-        x_cpu = move_to_device(detach(x), "cpu")
+        # Only pay the detach+copy cost if x or decoder_lengths are actually requested
+        needs_x = any(k in ("x", "decoder_lengths") for k in self.return_info)
+        x_cpu = move_to_device(detach(x), "cpu") if needs_x else None
 
         for key in self.return_info:
             if key == "x":
                 self.info[key].append(x_cpu)
             elif key == "y":
-                self.info[key].append(move_to_device(detach(y[0]), "cpu"))
+                y_cpu = move_to_device(detach(y[0]), "cpu")
+                self.info[key].append(y_cpu)
             elif key == "index":
-                self.info[key].append(move_to_device(detach(y[1]), "cpu"))
+                index_cpu = move_to_device(detach(y[1]), "cpu")
+                self.info[key].append(index_cpu)
             elif key == "decoder_lengths":
                 self.info[key].append(x_cpu["decoder_lengths"])
             else:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,94 @@
+from unittest.mock import MagicMock
+
+import torch
+
+from pytorch_forecasting.callbacks.predict import PredictCallback
+
+
+def _make_tensor(*shape):
+    # Non-leaf tensor so grad_fn is not None before detach, None after
+    return torch.zeros(*shape, requires_grad=True) + 0
+
+
+def _make_batch(batch_size=4, enc_len=10, dec_len=5):
+    x = {
+        "encoder_cont": _make_tensor(batch_size, enc_len, 2),
+        "decoder_cont": _make_tensor(batch_size, dec_len, 1),
+        "decoder_lengths": _make_tensor(batch_size).long(),
+    }
+    y = (_make_tensor(batch_size, dec_len), _make_tensor(batch_size, dec_len))
+    return x, y
+
+
+def _make_trainer():
+    return MagicMock()
+
+
+def _make_pl_module(return_value=None):
+    pl_module = MagicMock()
+    if return_value is not None:
+        pl_module.to_prediction.return_value = return_value
+        pl_module.to_quantiles.return_value = return_value
+    return pl_module
+
+
+def test_predictions_moved_to_cpu_prediction_mode():
+    """Predictions collected in prediction mode are detached and on CPU."""
+    output = _make_tensor(4, 5)
+    cb = PredictCallback(mode="prediction")
+    batch = _make_batch()
+    pl_module = _make_pl_module(return_value=output)
+
+    cb.on_predict_batch_end(_make_trainer(), pl_module, output, batch, batch_idx=0)
+
+    assert len(cb.predictions) == 1
+    assert cb.predictions[0].device == torch.device("cpu")
+    assert cb.predictions[0].grad_fn is None
+
+
+def test_raw_mode_dict_moved_to_cpu():
+    """Raw mode dict outputs are detached and moved to CPU before collection."""
+    outputs = {
+        "prediction": _make_tensor(4, 5),
+        "output": _make_tensor(4, 5, 2),
+    }
+    cb = PredictCallback(mode="raw")
+    batch = _make_batch()
+
+    cb.on_predict_batch_end(_make_trainer(), MagicMock(), outputs, batch, batch_idx=0)
+
+    assert isinstance(cb.predictions[0], dict)
+    for v in cb.predictions[0].values():
+        assert v.device == torch.device("cpu")
+        assert v.grad_fn is None
+
+
+def test_return_info_x_moved_to_cpu():
+    """When return_info includes 'x', the x dict is detached and on CPU."""
+    output = _make_tensor(4, 5)
+    cb = PredictCallback(mode="prediction", return_info=["x"])
+    batch = _make_batch()
+    pl_module = _make_pl_module(return_value=output)
+
+    cb.on_predict_batch_end(_make_trainer(), pl_module, output, batch, batch_idx=0)
+
+    x_stored = cb.info["x"][0]
+    assert isinstance(x_stored, dict)
+    for v in x_stored.values():
+        if isinstance(v, torch.Tensor):
+            assert v.device == torch.device("cpu")
+            assert v.grad_fn is None
+
+
+def test_return_info_y_and_decoder_lengths_moved_to_cpu():
+    """y[0] and decoder_lengths are detached and on CPU when requested."""
+    output = _make_tensor(4, 5)
+    cb = PredictCallback(mode="prediction", return_info=["y", "decoder_lengths"])
+    batch = _make_batch()
+    pl_module = _make_pl_module(return_value=output)
+
+    cb.on_predict_batch_end(_make_trainer(), pl_module, output, batch, batch_idx=0)
+
+    assert cb.info["y"][0].device == torch.device("cpu")
+    assert cb.info["y"][0].grad_fn is None
+    assert cb.info["decoder_lengths"][0].device == torch.device("cpu")


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2224

#### What does this implement/fix? Explain your changes.
As described in #2224, tensors collected in `on_predict_batch_end` were staying on the GPU between batches causing VRAM to grow linearly across the inference run.

Fixed by applying `move_to_device(detach(...), "cpu")` at each append site using
utilities already in pytorch_forecasting.utils, the same pattern already used in the v1 base model.  `x_cpu` is computed once and reused for both x and decoder_lengths to avoid reading from the GPU dict twice.
&nbsp;
#### What should a reviewer concentrate their feedback on?
Just the changes in `on_predict_batch_end` in `pytorch_forecasting/callbacks/predict.py`.
Nothing else was touched.
&nbsp;
#### Did you add any tests for the change?
Yes, I've added `tests/test_callbacks.py` with 4 tests covering prediction mode, raw mode dict output, the x dict, and y/decoder_lengths.

There was no existing test file for callbacks so created a standalone `test_callbacks.py` directly under `tests/`, following the same pattern as `test_metrics.py` rather than adding a subdirectory for a single file.

Since these run on CPU (no CUDA needed in CI), the device check alone would pass trivially even without the fix. 
To get around this, I've created tensors as non-leaf (`requires_grad=True` + an addition op) so they have a real `grad_fn`. 
The `assert grad_fn is None` then only passes if `.detach()` actually ran, making these tests meaningful on CPU too.
&nbsp;
#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing
