### PR TITLE
 Migrate samplers.py docstrings to NumPy style

### DIFF
--- a/pytorch_forecasting/data/samplers.py
+++ b/pytorch_forecasting/data/samplers.py
@@ -26,17 +26,23 @@ class GroupedSampler(Sampler):
         drop_last: bool = False,
     ):
         """
-        Initialize.
+        Initialize GroupedSampler.
 
-        Args:
-            sampler (Sampler or Iterable): Base sampler. Can be any iterable object
-            drop_last (bool): if to drop last mini-batch from a group if it is smaller than batch_size.
-                Defaults to False.
-            shuffle (bool): if to shuffle dataset. Defaults to False.
-            batch_size (int, optional): Number of samples in a mini-batch. This is rather the maximum number
-                of samples. Because mini-batches are grouped by prediction time, chances are that there
-                are multiple where batch size will be smaller than the maximum. Defaults to 64.
-        """  # noqa: E501
+        Parameters
+        ----------
+        sampler : Sampler or Iterable
+            Base sampler. Can be any iterable object.
+        batch_size : int, optional
+            Number of samples in a mini-batch. This is rather the maximum number
+            of samples. Because mini-batches are grouped by prediction time, chances
+            are that there are multiple where batch size will be smaller than the
+            maximum. Defaults to 64.
+        shuffle : bool, optional
+            If True, shuffle dataset. Defaults to False.
+        drop_last : bool, optional
+            If True, drop last mini-batch from a group if it is smaller than
+            batch_size. Defaults to False.
+        """
         # Since collections.abc.Iterable does not check for `__getitem__`, which
         # is one way for an object to be an iterable, we don't do an `isinstance`
         # check here.
@@ -65,12 +71,17 @@ class GroupedSampler(Sampler):
         """
         Create the groups which can be sampled.
 
-        Args:
-            sampler (Sampler): will have attribute data_source which is of type TimeSeriesDataSet.
+        Parameters
+        ----------
+        sampler : Sampler
+            Will have attribute data_source which is of type TimeSeriesDataSet.
 
-        Returns:
-            dict-like: dictionary-like object with data_source.index as values and group names as keys
-        """  # noqa: E501
+        Returns
+        -------
+        dict-like
+            Dictionary-like object with data_source.index as values and group
+            names as keys.
+        """
         raise NotImplementedError()
 
     def construct_batch_groups(self, groups):


### PR DESCRIPTION
# [DOC] Migrate samplers.py docstrings to NumPy style

## Reference Issues/PRs

Closes #2066

## What does this implement/fix? Explain your changes.

This PR converts Google-style docstrings to NumPy-style docstrings in `pytorch_forecasting/data/samplers.py` to align with the repository's documentation standards.

Changes made:

* `GroupedSampler.__init__`: Converted the Args section into NumPy-style Parameters format with proper type annotations and formatting.
* `GroupedSampler.get_groups`: Converted Args and Returns sections into NumPy-style format.

## What should a reviewer concentrate their feedback on?

* Correctness of NumPy-style docstring formatting
* Consistency with existing docstrings across the repository

## Did you add any tests for the change?

No new tests were added. Existing tests were run and all passed successfully.

## Any other comments?

This change is purely documentation-related and does not modify any functional code.

## PR checklist

* [x] The PR title starts with [DOC]
* [ ] Added/modified tests (not applicable)
* [x] Used pre-commit hooks / ensured formatting compliance (ruff checks passed)
