### PR TITLE
[BUG] Corrected typo in `AggregationMetric.reset()` from metrics to metric

### DIFF
--- a/pytorch_forecasting/metrics/base_metrics/_base_metrics.py
+++ b/pytorch_forecasting/metrics/base_metrics/_base_metrics.py
@@ -805,7 +805,7 @@ class AggregationMetric(Metric):
         pass
 
     def reset(self) -> None:
-        self.metrics.reset()
+        self.metric.reset()
 
     def persistent(self, mode: bool = False) -> None:
         self.metric.persistent(mode=mode)


### PR DESCRIPTION
closes #2251

## Description
When calling `.reset()` on `AggregationMetric`, the code originally referenced `self.metrics.reset()`. However, the assigned attribute in `__init__` is singular (`self.metric`). This caused an `AttributeError` crashing any multi-epoch training validation loops using this metric. 

## Changes Made
- Updated `self.metrics.reset()` to `self.metric.reset()` in `pytorch_forecasting/metrics/base_metrics/_base_metrics.py`.

CC : @phoeenniixx , @PranavBhatP