### PR TITLE
[BUG] correct inverted condition for `n_plotting_samples` default in `DeepAR`

### DIFF
--- a/pytorch_forecasting/models/deepar/_deepar.py
+++ b/pytorch_forecasting/models/deepar/_deepar.py
@@ -141,10 +141,9 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
         if logging_metrics is None:
             logging_metrics = nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE(), MASE()])
         if n_plotting_samples is None:
-            if n_validation_samples is None:
-                n_plotting_samples = n_validation_samples
-            else:
-                n_plotting_samples = 100
+            n_plotting_samples = (
+                n_validation_samples if n_validation_samples is not None else 100
+            )
         if static_categoricals is None:
             static_categoricals = []
         if static_reals is None:

--- a/tests/test_models/test_deepar.py
+++ b/tests/test_models/test_deepar.py
@@ -221,6 +221,30 @@ def test_predict_samples(model, dataloaders_with_covariates):
 
 
 @pytest.mark.parametrize(
+    "n_validation_samples,expected_n_plotting_samples",
+    [(None, 100), (50, 50), (200, 200)],
+)
+def test_n_plotting_samples_default(
+    dataloaders_with_covariates, n_validation_samples, expected_n_plotting_samples
+):
+    """Regression for #2234/#2246: when ``n_plotting_samples`` is left at its
+    default of ``None``, it should resolve to ``n_validation_samples`` if that
+    is given (matching the docstring) and fall back to ``100`` only when
+    ``n_validation_samples`` is also ``None``. The previous condition was
+    inverted and left ``n_plotting_samples`` as ``None`` in the all-defaults
+    case.
+    """
+    dataset = dataloaders_with_covariates["train"].dataset
+    model = DeepAR.from_dataset(
+        dataset,
+        hidden_size=5,
+        learning_rate=0.15,
+        n_validation_samples=n_validation_samples,
+    )
+    assert model.hparams.n_plotting_samples == expected_n_plotting_samples
+
+
+@pytest.mark.parametrize(
     "loss", [NormalDistributionLoss(), MultivariateNormalDistributionLoss()]
 )
 def test_pickle(dataloaders_with_covariates, loss):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2234. Fixes #2246.

#### What does this implement/fix? Explain your changes.

The \`DeepAR\` constructor docstring says:

> \`n_plotting_samples : int, optional\` ... Defaults to \`n_validation_samples\` if not None or 100 otherwise.

but the implementation flipped the branches:

\`\`\`python
if n_plotting_samples is None:
    if n_validation_samples is None:
        n_plotting_samples = n_validation_samples   # assigns None back
    else:
        n_plotting_samples = 100                     # only fires when validation samples are set
\`\`\`

So when both arguments are left at their default \`None\`, \`n_plotting_samples\` stays \`None\`, and \`create_log()\` later passes \`None\` as the sample count to the prediction/quantiles utilities.

#### Changes

- Replace the inverted \`if/else\` with a single conditional expression that matches the docstring:
  \`n_plotting_samples = n_validation_samples if n_validation_samples is not None else 100\`
- Add a parametrized regression test (\`test_n_plotting_samples_default\`) that asserts the resolved value for the all-defaults case (100), and for two explicit \`n_validation_samples\` values (50 and 200).

#### What should a reviewer concentrate their feedback on?

- Whether the docstring's documented behavior is the intended contract — the fix aligns the code with the docstring rather than the other way round.