### PR TITLE
[BUG] Fix tslib v2 static categorical/continuous feature mix-up

### DIFF
--- a/pytorch_forecasting/data/_tslib_data_module.py
+++ b/pytorch_forecasting/data/_tslib_data_module.py
@@ -219,8 +219,37 @@ class _TslibDataset(Dataset):
             x["future_relative_time_idx"] = torch.arange(0, prediction_length)
 
         if processed_data["static"] is not None:
-            x["static_categorical_features"] = processed_data["static"].unsqueeze(0)
-            x["static_continuous_features"] = processed_data["static"].unsqueeze(0)
+            static_features = processed_data["static"]
+            if not isinstance(static_features, torch.Tensor):
+                static_features = torch.tensor(static_features, dtype=torch.float32)
+            static_features = static_features.flatten()
+
+            static_feature_names = metadata["feature_names"]["static"]
+            static_categorical_names = set(
+                metadata["feature_names"]["static_categorical"]
+            )
+
+            static_categorical_indices = [
+                idx
+                for idx, name in enumerate(static_feature_names)
+                if name in static_categorical_names
+            ]
+            static_continuous_indices = [
+                idx
+                for idx, name in enumerate(static_feature_names)
+                if name not in static_categorical_names
+            ]
+
+            x["static_categorical_features"] = (
+                static_features[static_categorical_indices].unsqueeze(0)
+                if len(static_categorical_indices) > 0
+                else torch.zeros((1, 0), dtype=static_features.dtype)
+            )
+            x["static_continuous_features"] = (
+                static_features[static_continuous_indices].unsqueeze(0)
+                if len(static_continuous_indices) > 0
+                else torch.zeros((1, 0), dtype=static_features.dtype)
+            )
 
         if "target_scale" in processed_data:
             x["target_scale"] = processed_data["target_scale"]

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -440,3 +440,4 @@ def test_static_features_are_split_by_type_in_tslib_output():
     x, _ = next(iter(dm.train_dataloader()))
     assert x["static_categorical_features"].shape[-1] == 1
     assert x["static_continuous_features"].shape[-1] == 1
+    

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -440,4 +440,3 @@ def test_static_features_are_split_by_type_in_tslib_output():
     x, _ = next(iter(dm.train_dataloader()))
     assert x["static_categorical_features"].shape[-1] == 1
     assert x["static_continuous_features"].shape[-1] == 1
-    

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -394,3 +394,49 @@ def test_integration_with_datamodule(model, basic_tslib_data_module):
             assert test_output["prediction"].shape[1] == model.prediction_length
         except StopIteration:
             print("Test set is empty, skipping test testing")
+
+
+def test_static_features_are_split_by_type_in_tslib_output():
+    """Ensure static categorical and continuous tensors are separated in v2 output."""
+    np.random.seed(42)
+
+    df = pd.DataFrame(
+        {
+            "time_idx": np.tile(np.arange(30), 2),
+            "group_id": np.repeat(["group_0", "group_1"], 30),
+            "value": np.random.randn(60).astype(np.float32),
+            "temperature": np.random.randn(60).astype(np.float32),
+            "humidity": np.random.randn(60).astype(np.float32),
+            "pressure": np.random.randn(60).astype(np.float32),
+            "static_cont_feat": np.repeat([10.0, 20.0], 30).astype(np.float32),
+            "static_cat_feat": np.repeat([0, 1], 30),
+        }
+    )
+    df["group_id"] = df["group_id"].astype("category")
+
+    ts = TimeSeries(
+        df,
+        time="time_idx",
+        target="value",
+        group=["group_id"],
+        num=["value", "temperature", "humidity", "pressure", "static_cont_feat"],
+        cat=["static_cat_feat"],
+        known=["temperature", "humidity", "pressure", "time_idx"],
+        static=["static_cont_feat", "static_cat_feat"],
+    )
+
+    dm = TslibDataModule(
+        time_series_dataset=ts,
+        batch_size=2,
+        context_length=12,
+        prediction_length=8,
+    )
+    dm.setup(stage="fit")
+
+    metadata = dm.metadata
+    assert metadata["n_features"]["static_categorical"] == 1
+    assert metadata["n_features"]["static_continuous"] == 1
+
+    x, _ = next(iter(dm.train_dataloader()))
+    assert x["static_categorical_features"].shape[-1] == 1
+    assert x["static_continuous_features"].shape[-1] == 1


### PR DESCRIPTION
Reference Issues/PRs
Fixes #2261 

What does this implement/fix? Explain your changes.
-Fixes a bug in tslib v2 dataset output where both static_categorical_features and static_continuous_features were populated from the same static tensor.
-The change now splits static features using metadata indices so categorical and continuous static tensors are emitted separately and correctly.

What should a reviewer concentrate their feedback on?
-Correctness of static feature index mapping from metadata
-Tensor slicing behavior when one static type is missing/empty
-Backward compatibility of dataloader batch structure for tslib v2 consumers

Did you add any tests for the change?
Yes. Added/updated regression coverage in:
/home/runner/work/pytorch-forecasting/pytorch-forecasting/tests/test_models/test_timexer_v2.py
and validated with: python -m pytest tests/test_models/test_timexer_v2.py -q

Any other comments?
No.

PR checklist
- The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or    
   improving code, [DOC] - writing or improving documentation or docstrings.
- Added/modified tests
- Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with pre-commit install.  
To run hooks independent of commit, execute pre-commit run --all-files