### PR TITLE
[BUG] FIXED: Potential sequence length bug in preprocessed record (Obvious but Critical)

### DIFF
--- a/pytorch_forecasting/data/_tslib_data_module.py
+++ b/pytorch_forecasting/data/_tslib_data_module.py
@@ -602,7 +602,7 @@ class TslibDataModule(LightningDataModule):
             "target": target,
             "static": series["st"],
             "group": series.get("group", torch.tensor([0])),
-            "length": len(series),
+            "length": len(timestep),
             "time_mask": mask_timestep,
             "cutoff_time": cutoff_time,
             "timestep": timestep,

--- a/pytorch_forecasting/data/tests/test_tslib_data_module.py
+++ b/pytorch_forecasting/data/tests/test_tslib_data_module.py
@@ -468,6 +468,7 @@ def test_preprocess_data(tslib_data_module, sample_timeseries_data):
 
     expected_length = len(original_sample["t"])
 
+    assert processed["length"] == expected_length   
     assert processed["features"]["categorical"].shape[0] == expected_length
     assert processed["features"]["continuous"].shape[0] == expected_length
     assert processed["target"].shape[0] == expected_length

--- a/pytorch_forecasting/data/tests/test_tslib_data_module.py
+++ b/pytorch_forecasting/data/tests/test_tslib_data_module.py
@@ -468,7 +468,7 @@ def test_preprocess_data(tslib_data_module, sample_timeseries_data):
 
     expected_length = len(original_sample["t"])
 
-    assert processed["length"] == expected_length   
+    assert processed["length"] == expected_length
     assert processed["features"]["categorical"].shape[0] == expected_length
     assert processed["features"]["continuous"].shape[0] == expected_length
     assert processed["target"].shape[0] == expected_length


### PR DESCRIPTION
# Reference Issues/PRs
Fixes #2265

# What does this implement/fix? Explain your changes.
This PR fixes sequence-length metadata in tslib preprocessing.
_preprocess_data() was using len(series) (number of keys in the record) instead of the true time dimension length.
It now sets length from the timestep/sequence length, so downstream logic receives correct series length metadata.

# What should a reviewer concentrate their feedback on?
- Correctness of the length calculation change in _preprocess_data()
- Any downstream assumptions that depend on processed["length"]
- Backward compatibility for existing tslib data flows

# Did you add any tests for the change?
Yes. Added/updated a regression assertion in test_preprocess_data to verify processed["length"] == len(original_sample["t"]).

# Any other comments?
This is a targeted bugfix with minimal surface-area changes.

# PR checklist
 - The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
 - Added/modified tests
 - Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with pre-commit install. To run hooks independent of commit, execute pre-commit run --all-files