### PR TITLE
feat: add py.typed marker for PEP 561 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,3 +237,6 @@ filterwarnings = [
     "default::FutureWarning",
     "ignore::UserWarning"
 ]
+
+[tool.setuptools.package-data]
+pytorch_forecasting = ["py.typed"]


### PR DESCRIPTION
## Summary
Adds an empty `py.typed` marker file to the `pytorch_forecasting/` package directory as specified by PEP 561.

## Problem
Type checkers (Pyright, Pylance, mypy) treat `pytorch-forecasting` as untyped because there is no `py.typed` marker, causing warnings like:
`Stub file not found for "pytorch_forecasting"` (reportMissingTypeStubs)

## Fix
- Add an empty `pytorch_forecasting/py.typed` marker file (zero bytes, no logic changes)
- - Add `[tool.setuptools.package-data]` entry in `pyproject.toml` so the file is included in the built distribution
No logic changes, no new dependencies.