### PR TITLE
[MNT] Add version bounds to prevent installation of compromised `lightning` versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ description = "Forecasting timeseries with PyTorch - dataloaders, normalizers, m
 dependencies = [
   "numpy<=3.0.0",
   "torch >=2.0.0,!=2.0.1,<3.0.0",
-  "lightning >=2.0.0,<2.7.0",
+  "lightning >=2.0.0, !=2.6.2, != 2.6.3, <2.7.0",
   "scipy >=1.8,<2.0",
   "pandas >=1.3.0,<3.1.0",
   "scikit-learn >=1.2,<2.0",


### PR DESCRIPTION
This PR adds version bounds to prevent installation of compromised `lightning` versions - `lightning 2.6.2` and `lightning 2.6.3`. 
For more info please refer: https://thehackernews.com/2026/04/pytorch-lightning-compromised-in-pypi.html and https://github.com/Lightning-AI/pytorch-lightning/issues/21691