### PR TITLE
[BUG] Fix NHiTS NameError when dataset has static reals but no time-varying encoder covariates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version release focusing on:
 
 ### Fixes
 
+* [BUG] Fix `NHiTS.forward()` `NameError` when dataset has static reals but no time-varying encoder covariates (#2243) @kpal002
 * [BUG] Import issue for `SettingWithCopyWarning` fixed (#2036) @lucifer4073
 * [BUG] Remove outdated strict naming convention test in test_all_estim… (#2190) @AyushDineshRathi
 * [BUG] Fix _load_config() to support .pkl file paths (#2199) @Quant-Code-Hacker

--- a/pytorch_forecasting/models/nhits/_nhits.py
+++ b/pytorch_forecasting/models/nhits/_nhits.py
@@ -358,10 +358,14 @@ class NHiTS(BaseModelWithCovariates):
             output of model
         """
         # covariates
-        if self.encoder_covariate_size > 0:
+        if self.encoder_covariate_size > 0 or self.static_size > 0:
             encoder_features = self.extract_features(
                 x, self.embeddings, period="encoder"
             )
+        else:
+            encoder_features = {}
+
+        if self.encoder_covariate_size > 0:
             encoder_x_t = torch.concat(
                 [
                     encoder_features[name]

--- a/tests/test_models/test_nhits.py
+++ b/tests/test_models/test_nhits.py
@@ -216,3 +216,35 @@ def test_prediction_length(max_prediction_length: int):
         return_index=True,
         return_decoder_lengths=True,
     )
+
+
+def test_nhits_static_reals_forward():
+    """Regression test: NHiTS.forward() must not raise NameError when the dataset
+    introduces static real variables (e.g. via add_target_scales=True) but has no
+    time-varying encoder covariates, i.e. encoder_covariate_size == 0 < static_size.
+    """
+    n_timeseries = 10
+    time_points = 30
+    data = pd.DataFrame(
+        {
+            "target": np.random.rand(time_points * n_timeseries),
+            "time_idx": np.tile(np.arange(time_points), n_timeseries),
+            "group_id": np.repeat(np.arange(n_timeseries), time_points),
+        }
+    )
+    dataset = TimeSeriesDataSet(
+        data,
+        time_idx="time_idx",
+        target="target",
+        group_ids=["group_id"],
+        time_varying_unknown_reals=["target"],
+        max_encoder_length=10,
+        max_prediction_length=5,
+        add_target_scales=True,  # introduces static reals, encoder_covariate_size stays 0
+    )
+    dataloader = dataset.to_dataloader(train=True, batch_size=4, num_workers=0)
+    model = NHiTS.from_dataset(dataset, hidden_size=8)
+
+    batch, _ = next(iter(dataloader))
+    # must not raise NameError: free variable 'encoder_features' referenced before assignment
+    model(batch)

--- a/tests/test_models/test_nhits.py
+++ b/tests/test_models/test_nhits.py
@@ -240,11 +240,11 @@ def test_nhits_static_reals_forward():
         time_varying_unknown_reals=["target"],
         max_encoder_length=10,
         max_prediction_length=5,
-        add_target_scales=True,  # introduces static reals, encoder_covariate_size stays 0
+        add_target_scales=True,  # introduces static reals; encoder_covariate_size=0
     )
     dataloader = dataset.to_dataloader(train=True, batch_size=4, num_workers=0)
     model = NHiTS.from_dataset(dataset, hidden_size=8)
 
     batch, _ = next(iter(dataloader))
-    # must not raise NameError: free variable 'encoder_features' referenced before assignment
+    # must not raise NameError on encoder_features
     model(batch)


### PR DESCRIPTION
Closes #2281.

## Summary

Fixes a `NameError` crash in `NHiTS.forward()` that occurs whenever a `TimeSeriesDataSet` introduces static real variables (e.g. `add_target_scales=True`) but has no time-varying encoder covariates.

### Root cause

`encoder_features` was only defined inside `if self.encoder_covariate_size > 0`, but the static-variable branch below it referenced `encoder_features` unconditionally:

```python
# only set when encoder_covariate_size > 0
if self.encoder_covariate_size > 0:
    encoder_features = self.extract_features(...)
    ...
else:
    encoder_x_t = None

# always executed when static_size > 0 → NameError if branch above was skipped
if self.static_size > 0:
    x_s = torch.concat([encoder_features[name][:, 0] ...])
```

`encoder_covariate_size` correctly excludes static reals (they are not time-dependent), so the guard was `0` while `static_size > 0`, causing the crash.

### Fix

Hoist the `extract_features("encoder")` call to fire whenever **either** encoder covariates or static variables are present. The time-varying `encoder_x_t` tensor is still built only when `encoder_covariate_size > 0`, so model weights and dimensions are unchanged.

```python
if self.encoder_covariate_size > 0 or self.static_size > 0:
    encoder_features = self.extract_features(x, self.embeddings, period="encoder")
else:
    encoder_features = {}

if self.encoder_covariate_size > 0:
    encoder_x_t = torch.concat([...], dim=2)
else:
    encoder_x_t = None
```

### Changes

- `pytorch_forecasting/models/nhits/_nhits.py` — one-line guard change + restructured encoder block
- `tests/test_models/test_nhits.py` — `test_nhits_static_reals_forward` regression test reproducing the exact crash path (`add_target_scales=True`, no time-varying covariates)
- `CHANGELOG.md` — entry added under v1.7.0 Fixes following the `[BUG] ... (#PR) @username` format used by the project

### Minimal reproducer

```python
from pytorch_forecasting.data.examples import generate_ar_data
from pytorch_forecasting import TimeSeriesDataSet, NHiTS

data = generate_ar_data(seasonality=10.0, timesteps=400, n_series=100, seed=42)
dataset = TimeSeriesDataSet(
    data, time_idx="time_idx", target="value", group_ids=["series"],
    time_varying_unknown_reals=["value"],
    max_encoder_length=60, max_prediction_length=20,
    add_target_scales=True,  # introduces static reals
)
model = NHiTS.from_dataset(dataset)
batch, _ = next(iter(dataset.to_dataloader(train=True, batch_size=8)))
model(batch)  # NameError before this fix
```