### PR TITLE
 [ENH] M mode test for TimeXer v2

### DIFF
--- a/docs/source/tutorials/stallion.ipynb
+++ b/docs/source/tutorials/stallion.ipynb
@@ -41,7 +41,6 @@
    "source": [
     "import warnings\n",
     "\n",
-    "\n",
     "warnings.filterwarnings(\"ignore\")  # avoid printing out absolute paths"
    ]
   },

--- a/docs/source/tutorials/stallion.ipynb
+++ b/docs/source/tutorials/stallion.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -40,6 +40,7 @@
    "outputs": [],
    "source": [
     "import warnings\n",
+    "\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")  # avoid printing out absolute paths"
    ]

--- a/docs/source/tutorials/stallion.ipynb
+++ b/docs/source/tutorials/stallion.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -40,6 +40,7 @@
    "outputs": [],
    "source": [
     "import warnings\n",
+    "\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")  # avoid printing out absolute paths"
    ]

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -394,29 +394,24 @@ def test_integration_with_datamodule(model, basic_tslib_data_module):
         except StopIteration:
             print("Test set is empty, skipping test testing")
 
-    def test_m_mode(sample_multivariate_multi_series_data):
-        """Test M mode (multiple series) with TimeXer model."""
-        df = sample_multivariate_multi_series_data
-        dataset = TimeSeries(
-            data=df,
-            time="time_idx",
-            target=["target1", "target2"],  # M mode uses multiple targets
-            group=["group_id"],
-            num=["temperature", "humidity", "pressure", "wind_speed"],
-            known=["temperature", "humidity", "pressure", "wind_speed", "time_idx"],
-        )
 
-        data_module = TslibDataModule(
-            time_series_dataset=dataset,
-            batch_size=2,
-            context_length=12,
-            prediction_length=8,
-            train_val_test_split=(0.7, 0.15, 0.15),
-        )
-        data_module.setup()
-        metadata = data_module.metadata
+from pytorch_forecasting.models.timexer._timexer_pkg_v2 import TimeXer_pkg_v2
 
-        model = TimeXer(
+
+def test_m_mode(sample_multivariate_multi_series_data):
+    """Test M mode (multiple series) with TimeXer model."""
+    df = sample_multivariate_multi_series_data
+    dataset = TimeSeries(
+        data=df,
+        time="time_idx",
+        target=["target1", "target2"],  # M mode uses multiple targets
+        group=["group_id"],
+        num=["temperature", "humidity", "pressure", "wind_speed"],
+        known=["temperature", "humidity", "pressure", "wind_speed", "time_idx"],
+    )
+
+    pkg = TimeXer_pkg_v2(
+        model_cfg=dict(
             loss=MAE(),
             hidden_size=64,
             n_heads=8,
@@ -424,15 +419,30 @@ def test_integration_with_datamodule(model, basic_tslib_data_module):
             d_ff=256,
             dropout=0.1,
             patch_length=4,
-            metadata=metadata,
-        )
+        ),
+        datamodule_cfg=dict(
+            batch_size=2,
+            context_length=12,
+            prediction_length=8,
+            train_val_test_split=(0.7, 0.15, 0.15),
+        ),
+        trainer_cfg=dict(
+            fast_dev_run=True,
+        ),
+    )
 
-        train_dataloader = data_module.train_dataloader()
-        batch = next(iter(train_dataloader))[0]
+    # Build datamodule and model under the hood to test forward pass
+    pkg.datamodule = pkg._build_datamodule(dataset)
+    pkg.datamodule.setup(stage="fit")
 
-        model.eval()
-        with torch.no_grad():
-            output = model(batch)
+    pkg._build_model(metadata=pkg.datamodule.metadata, **pkg.model_cfg)
 
-        predictions = output["prediction"]
-        assert predictions.shape == (2, 8, 2)
+    train_dataloader = pkg.datamodule.train_dataloader()
+    batch = next(iter(train_dataloader))[0]
+
+    pkg.model.eval()
+    with torch.no_grad():
+        output = pkg.model(batch)
+
+    predictions = output["prediction"]
+    assert predictions.shape == (2, 8, 2)

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -400,12 +400,12 @@ def test_integration_with_datamodule(model, basic_tslib_data_module):
         dataset = TimeSeries(
             data=df,
             time="time_idx",
-            target=["target1", "target2"], # M mode uses multiple targets
+            target=["target1", "target2"],  # M mode uses multiple targets
             group=["group_id"],
             num=["temperature", "humidity", "pressure", "wind_speed"],
             known=["temperature", "humidity", "pressure", "wind_speed", "time_idx"],
         )
-        
+
         data_module = TslibDataModule(
             time_series_dataset=dataset,
             batch_size=2,
@@ -415,7 +415,7 @@ def test_integration_with_datamodule(model, basic_tslib_data_module):
         )
         data_module.setup()
         metadata = data_module.metadata
-        
+
         model = TimeXer(
             loss=MAE(),
             hidden_size=64,
@@ -426,13 +426,13 @@ def test_integration_with_datamodule(model, basic_tslib_data_module):
             patch_length=4,
             metadata=metadata,
         )
-        
+
         train_dataloader = data_module.train_dataloader()
         batch = next(iter(train_dataloader))[0]
-        
+
         model.eval()
         with torch.no_grad():
             output = model(batch)
-            
+
         predictions = output["prediction"]
         assert predictions.shape == (2, 8, 2)

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -3,7 +3,6 @@ Basic test framework for TimeXer v2 model.
 TODO:
 - Add tests for testing the scaling of features, once that is implemented in the D1/D2
   level.
-- Add tests for the M mode (multiple series) once that is implemented.
 """
 
 import numpy as np
@@ -394,3 +393,46 @@ def test_integration_with_datamodule(model, basic_tslib_data_module):
             assert test_output["prediction"].shape[1] == model.prediction_length
         except StopIteration:
             print("Test set is empty, skipping test testing")
+
+    def test_m_mode(sample_multivariate_multi_series_data):
+        """Test M mode (multiple series) with TimeXer model."""
+        df = sample_multivariate_multi_series_data
+        dataset = TimeSeries(
+            data=df,
+            time="time_idx",
+            target=["target1", "target2"], # M mode uses multiple targets
+            group=["group_id"],
+            num=["temperature", "humidity", "pressure", "wind_speed"],
+            known=["temperature", "humidity", "pressure", "wind_speed", "time_idx"],
+        )
+        
+        data_module = TslibDataModule(
+            time_series_dataset=dataset,
+            batch_size=2,
+            context_length=12,
+            prediction_length=8,
+            train_val_test_split=(0.7, 0.15, 0.15),
+        )
+        data_module.setup()
+        metadata = data_module.metadata
+        
+        model = TimeXer(
+            loss=MAE(),
+            hidden_size=64,
+            n_heads=8,
+            e_layers=2,
+            d_ff=256,
+            dropout=0.1,
+            patch_length=4,
+            metadata=metadata,
+        )
+        
+        train_dataloader = data_module.train_dataloader()
+        batch = next(iter(train_dataloader))[0]
+        
+        model.eval()
+        with torch.no_grad():
+            output = model(batch)
+            
+        predictions = output["prediction"]
+        assert predictions.shape == (2, 8, 2)


### PR DESCRIPTION
<!--
Welcome to pytorch-forecasting, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/pytorch-forecasting/issues
-->
Resolves a codebase TODO.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
 Added an M mode (multiple series) test to `test_timexer_v2.py` to resolve the actionable TODO comment requesting tests for multiple series forecasting now that the feature is successfully implemented.Improves test coverage and validates that the TimeXer v2 model correctly processes multi-target datasets.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
* Verify that the data format in the test aligns with the expected M mode usage.

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
Yes, added `test_m_mode` to `tests/test_models/test_timexer_v2.py`.

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`

<!--
Thanks for contributing!
-->

