### PR TITLE
[ENH] Add multiloss support to `ptf` v2

### DIFF
--- a/docs/source/tutorials/ptf_V2_example.ipynb
+++ b/docs/source/tutorials/ptf_V2_example.ipynb
@@ -1747,8 +1747,8 @@
    "source": [
     "print(\"First Predicted Value:\")\n",
     "print(\"Index:\", preds[\"index\"][0].item())\n",
-    "print(\"Prediction:\", preds[\"prediction\"][0].item())\n",
-    "print(\"Actual:\", preds[\"y\"][0].item())"
+    "print(\"Prediction:\", preds[\"prediction\"][0][0].item())\n",
+    "print(\"Actual:\", preds[\"y\"][0][0].item())"
    ]
   }
  ],

--- a/docs/source/tutorials/ptf_V2_example.ipynb
+++ b/docs/source/tutorials/ptf_V2_example.ipynb
@@ -1039,8 +1039,8 @@
    "source": [
     "print(\"First Predicted Value:\")\n",
     "print(\"Index:\", preds[\"index\"][0].item())\n",
-    "print(\"Prediction:\", preds[\"prediction\"][0].item())\n",
-    "print(\"Actual:\", preds[\"y\"][0].item())"
+    "print(\"Prediction:\", preds[\"prediction\"][0][0].item())\n",
+    "print(\"Actual:\", preds[\"y\"][0][0].item())"
    ]
   },
   {

--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -102,9 +102,18 @@ class PredictCallback(BasePredictionWriter):
 
         for key, data_list in self.info.items():
             if isinstance(data_list[0], dict):
-                collated_info = {
-                    k: torch.cat([d[k] for d in data_list]) for k in data_list[0].keys()
-                }
+                collated_info = {}
+                for k in data_list[0].keys():
+                    batch_elements = [d[k] for d in data_list]
+
+                    if isinstance(batch_elements[0], (list, tuple)):
+                        n_items = len(batch_elements[0])
+                        collated_info[k] = [
+                            torch.cat([elem[i] for elem in batch_elements])
+                            for i in range(n_items)
+                        ]
+                    else:
+                        collated_info[k] = torch.cat(batch_elements)
             else:
                 collated_info = torch.cat(data_list)
             final_result[key] = collated_info

--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -131,8 +131,15 @@ class PredictCallback(BasePredictionWriter):
                         ]
                     else:
                         collated_info[k] = torch.cat(batch_elements)
+
+            elif isinstance(data_list[0], (list, tuple)):
+                n_items = len(data_list[0])
+                collated_info = [
+                    torch.cat([elem[i] for elem in data_list]) for i in range(n_items)
+                ]
             else:
                 collated_info = torch.cat(data_list)
+
             final_result[key] = collated_info
 
         self._result = final_result

--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -92,11 +92,28 @@ class PredictCallback(BasePredictionWriter):
         """Collate all batch results into final tensors."""
         if self.mode == "raw" and isinstance(self.predictions[0], dict):
             keys = self.predictions[0].keys()
-            collated_preds = {
-                key: torch.cat([p[key] for p in self.predictions]) for key in keys
-            }
+            collated_preds = {}
+            for key in keys:
+                batch_elements = [p[key] for p in self.predictions]
+                if isinstance(batch_elements[0], (list, tuple)):
+                    n_items = len(batch_elements[0])
+                    collated_preds[key] = [
+                        torch.cat([elem[i] for elem in batch_elements])
+                        for i in range(n_items)
+                    ]
+                else:
+                    collated_preds[key] = torch.cat(batch_elements)
         else:
-            collated_preds = {"prediction": torch.cat(self.predictions)}
+            if isinstance(self.predictions[0], (list, tuple)):
+                n_items = len(self.predictions[0])
+                collated_preds = {
+                    "prediction": [
+                        torch.cat([p[i] for p in self.predictions])
+                        for i in range(n_items)
+                    ]
+                }
+            else:
+                collated_preds = {"prediction": torch.cat(self.predictions)}
 
         final_result = collated_preds
 

--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -61,6 +61,8 @@ class PredictCallback(BasePredictionWriter):
 
         if self.mode == "raw":
             processed_output = outputs
+            if not isinstance(processed_output["prediction"], (list, tuple)):
+                processed_output["prediction"] = [processed_output["prediction"]]
         elif self.mode == "prediction":
             processed_output = pl_module.to_prediction(outputs, **self.mode_kwargs)
         elif self.mode == "quantiles":

--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -88,59 +88,31 @@ class PredictCallback(BasePredictionWriter):
             else:
                 warn(f"Unknown return_info key: {key}")
 
+    @staticmethod
+    def _collate(items: list[Any]) -> Any:
+        """Recursively concatenate a list of per-batch tensors/dicts/lists into one."""
+        first = items[0]
+        if isinstance(first, dict):
+            return {
+                key: PredictCallback._collate([item[key] for item in items])
+                for key in first
+            }
+        if isinstance(first, (list, tuple)):
+            n = len(first)
+            return [
+                PredictCallback._collate([item[i] for item in items]) for i in range(n)
+            ]
+        return torch.cat(items)
+
     def on_predict_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
         """Collate all batch results into final tensors."""
-        if self.mode == "raw" and isinstance(self.predictions[0], dict):
-            keys = self.predictions[0].keys()
-            collated_preds = {}
-            for key in keys:
-                batch_elements = [p[key] for p in self.predictions]
-                if isinstance(batch_elements[0], (list, tuple)):
-                    n_items = len(batch_elements[0])
-                    collated_preds[key] = [
-                        torch.cat([elem[i] for elem in batch_elements])
-                        for i in range(n_items)
-                    ]
-                else:
-                    collated_preds[key] = torch.cat(batch_elements)
-        else:
-            if isinstance(self.predictions[0], (list, tuple)):
-                n_items = len(self.predictions[0])
-                collated_preds = {
-                    "prediction": [
-                        torch.cat([p[i] for p in self.predictions])
-                        for i in range(n_items)
-                    ]
-                }
-            else:
-                collated_preds = {"prediction": torch.cat(self.predictions)}
+        is_raw_dict = self.mode == "raw" and isinstance(self.predictions[0], dict)
+        collated_preds = self._collate(self.predictions)
 
-        final_result = collated_preds
+        final_result = collated_preds if is_raw_dict else {"prediction": collated_preds}
 
         for key, data_list in self.info.items():
-            if isinstance(data_list[0], dict):
-                collated_info = {}
-                for k in data_list[0].keys():
-                    batch_elements = [d[k] for d in data_list]
-
-                    if isinstance(batch_elements[0], (list, tuple)):
-                        n_items = len(batch_elements[0])
-                        collated_info[k] = [
-                            torch.cat([elem[i] for elem in batch_elements])
-                            for i in range(n_items)
-                        ]
-                    else:
-                        collated_info[k] = torch.cat(batch_elements)
-
-            elif isinstance(data_list[0], (list, tuple)):
-                n_items = len(data_list[0])
-                collated_info = [
-                    torch.cat([elem[i] for elem in data_list]) for i in range(n_items)
-                ]
-            else:
-                collated_info = torch.cat(data_list)
-
-            final_result[key] = collated_info
+            final_result[key] = self._collate(data_list)
 
         self._result = final_result
         self._reset_data(result=False)

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -313,6 +313,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         features = sample["x"]
         times = sample["t"]
         cutoff_time = sample["cutoff_time"]
+        weights = sample.get("weights", None)
 
         time_mask = torch.tensor(times <= cutoff_time, dtype=torch.bool)
 
@@ -325,6 +326,10 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             features = features.float()
         else:
             features = torch.tensor(features, dtype=torch.float32)
+        if isinstance(weights, torch.Tensor):
+            weights = weights.float()
+        elif weights is not None:
+            weights = torch.tensor(weights, dtype=torch.float32)
 
         # TODO: add scalers, target normalizers etc.
 
@@ -342,6 +347,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         return {
             "features": {"categorical": categorical, "continuous": continuous},
             "target": target,
+            "weights": weights,
             "static": sample.get("st", None),
             "group": sample.get("group", torch.tensor([0])),
             "length": len(target),
@@ -444,9 +450,22 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             decoder_indices = slice(start_idx + enc_length, end_idx)
 
             target_past = data["target"][encoder_indices]
-            target_scale = target_past[~torch.isnan(target_past)].abs().mean()
-            if torch.isnan(target_scale) or target_scale == 0:
-                target_scale = torch.tensor(1.0)
+            valid_mask = ~torch.isnan(target_past)
+            abs_vals = target_past.abs().masked_fill(~valid_mask, 0.0)
+            counts = valid_mask.sum(dim=0).clamp(min=1)
+            target_scale_vec = abs_vals.sum(dim=0) / counts  # (n_targets,)
+            target_scale_vec = torch.where(
+                (target_scale_vec == 0) | torch.isnan(target_scale_vec),
+                torch.ones_like(target_scale_vec),
+                target_scale_vec,
+            )
+
+            if self.data_module.n_targets > 1:
+                target_scale = [
+                    target_scale_vec[i] for i in range(self.data_module.n_targets)
+                ]
+            else:
+                target_scale = target_scale_vec.squeeze(0)
 
             encoder_mask = (
                 data["time_mask"][encoder_indices]
@@ -560,13 +579,19 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                     )
 
             y = data["target"][decoder_indices]
+            weights = data["weights"]
+            decoder_weights = (
+                weights[decoder_indices]
+                if weights is not None
+                else torch.ones(pred_length, dtype=torch.float32)
+            )
 
             if self.data_module.n_targets > 1:
                 y = [t.squeeze(-1) for t in torch.split(y, 1, dim=1)]
             else:
                 y = y.squeeze(-1)
 
-            return x, y
+            return x, (y, decoder_weights)
 
     def _create_windows(self, indices: torch.Tensor) -> list[tuple[int, int, int, int]]:
         """Generate sliding windows for training, validation, and testing.
@@ -733,10 +758,19 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             "target_past": torch.stack([x["target_past"] for x, _ in batch]),
             "encoder_time_idx": torch.stack([x["encoder_time_idx"] for x, _ in batch]),
             "decoder_time_idx": torch.stack([x["decoder_time_idx"] for x, _ in batch]),
-            "target_scale": torch.stack([x["target_scale"] for x, _ in batch]),
             "encoder_mask": torch.stack([x["encoder_mask"] for x, _ in batch]),
             "decoder_mask": torch.stack([x["decoder_mask"] for x, _ in batch]),
         }
+        if isinstance(batch[0][0]["target_scale"], list | tuple):
+            num_targets = len(batch[0][0]["target_scale"])
+            target_scale = [
+                torch.stack([x["target_scale"][i] for x, _ in batch])
+                for i in range(num_targets)
+            ]
+        else:
+            target_scale = torch.stack([x["target_scale"] for x, _ in batch])
+
+        x_batch["target_scale"] = target_scale
 
         if "static_categorical_features" in batch[0][0]:
             x_batch["static_categorical_features"] = torch.stack(
@@ -746,13 +780,16 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 [x["static_continuous_features"] for x, _ in batch]
             )
 
-        if isinstance(batch[0][1], list | tuple):
-            num_targets = len(batch[0][1])
+        if isinstance(batch[0][1][0], list | tuple):
+            num_targets = len(batch[0][1][0])
             y_batch = []
             for i in range(num_targets):
-                target_tensors = [sample_y[i] for _, sample_y in batch]
+                target_tensors = [sample_y[0][i] for _, sample_y in batch]
                 stacked_target = torch.stack(target_tensors)
                 y_batch.append(stacked_target)
         else:
-            y_batch = torch.stack([y for _, y in batch])
-        return x_batch, y_batch
+            y_batch = torch.stack([y[0] for _, y in batch])
+
+        weight_batch = torch.stack([sample_y[1] for _, sample_y in batch])
+
+        return x_batch, (y_batch, weight_batch)

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -386,25 +386,10 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         weights = sample.get("weights", None)
 
         target = target.float()
-        features = features.float()
-        time_mask = torch.tensor(times <= cutoff_time, dtype=torch.bool)
-
-        if isinstance(target, torch.Tensor):
-            target = target.float()
-        else:
-            target = torch.tensor(target, dtype=torch.float32)
-
-        if isinstance(features, torch.Tensor):
-            features = features.float()
-        else:
-            features = torch.tensor(features, dtype=torch.float32)
-        if isinstance(weights, torch.Tensor):
-            weights = weights.float()
-        elif weights is not None:
-            weights = torch.tensor(weights, dtype=torch.float32)
-
         if target.ndim == 1:
             target = target.unsqueeze(-1)
+        features = features.float()
+        weights = weights.float()
 
         time_mask = torch.tensor(times <= cutoff_time, dtype=torch.bool)
         return target, features, times, time_mask, weights
@@ -685,22 +670,6 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 target_scale_vec,
             )
 
-            if self.data_module.n_targets > 1:
-                target_scale = [
-                    target_scale_vec[i] for i in range(self.data_module.n_targets)
-                ]
-            else:
-                target_scale = target_scale_vec.squeeze(0)
-            valid_mask = ~torch.isnan(target_past)
-            abs_vals = target_past.abs().masked_fill(~valid_mask, 0.0)
-            counts = valid_mask.sum(dim=0).clamp(min=1)
-            target_scale_vec = abs_vals.sum(dim=0) / counts  # (n_targets,)
-            target_scale_vec = torch.where(
-                (target_scale_vec == 0) | torch.isnan(target_scale_vec),
-                torch.ones_like(target_scale_vec),
-                target_scale_vec,
-            )
-
             target_scale = [
                 target_scale_vec[i] for i in range(self.data_module.n_targets)
             ]
@@ -833,11 +802,6 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 else torch.ones(pred_length, dtype=torch.float32)
             )
 
-            if y.shape[-1] > 1:
-                y = [y[:, i] for i in range(y.shape[-1])]
-            else:
-                y = y.squeeze(-1)
-            return x, y
             y = [t.squeeze(-1) for t in torch.split(y, 1, dim=1)]
 
             return x, (y, decoder_weights)

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -798,11 +798,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
             y = data["target"][decoder_indices]
             weights = data["weights"]
-            decoder_weights = (
-                weights[decoder_indices]
-                if weights is not None
-                else torch.ones(pred_length, dtype=torch.float32)
-            )
+            decoder_weights = weights[decoder_indices] if weights is not None else None
 
             y = [t.squeeze(-1) for t in torch.split(y, 1, dim=1)]
 
@@ -1115,6 +1111,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             stacked_target = torch.stack(target_tensors)
             y_batch.append(stacked_target)
 
-        weight_batch = torch.stack([sample_y[1] for _, sample_y in batch])
+        weights = [sample_y[1] for _, sample_y in batch]
+        weight_batch = None if weights[0] is None else torch.stack(weights)
 
         return x_batch, (y_batch, weight_batch)

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -460,12 +460,9 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 target_scale_vec,
             )
 
-            if self.data_module.n_targets > 1:
-                target_scale = [
-                    target_scale_vec[i] for i in range(self.data_module.n_targets)
-                ]
-            else:
-                target_scale = target_scale_vec.squeeze(0)
+            target_scale = [
+                target_scale_vec[i] for i in range(self.data_module.n_targets)
+            ]
 
             encoder_mask = (
                 data["time_mask"][encoder_indices]
@@ -586,10 +583,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 else torch.ones(pred_length, dtype=torch.float32)
             )
 
-            if self.data_module.n_targets > 1:
-                y = [t.squeeze(-1) for t in torch.split(y, 1, dim=1)]
-            else:
-                y = y.squeeze(-1)
+            y = [t.squeeze(-1) for t in torch.split(y, 1, dim=1)]
 
             return x, (y, decoder_weights)
 
@@ -761,14 +755,12 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             "encoder_mask": torch.stack([x["encoder_mask"] for x, _ in batch]),
             "decoder_mask": torch.stack([x["decoder_mask"] for x, _ in batch]),
         }
-        if isinstance(batch[0][0]["target_scale"], list | tuple):
-            num_targets = len(batch[0][0]["target_scale"])
-            target_scale = [
-                torch.stack([x["target_scale"][i] for x, _ in batch])
-                for i in range(num_targets)
-            ]
-        else:
-            target_scale = torch.stack([x["target_scale"] for x, _ in batch])
+
+        num_targets = len(batch[0][0]["target_scale"])
+        target_scale = [
+            torch.stack([x["target_scale"][i] for x, _ in batch])
+            for i in range(num_targets)
+        ]
 
         x_batch["target_scale"] = target_scale
 
@@ -780,15 +772,12 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 [x["static_continuous_features"] for x, _ in batch]
             )
 
-        if isinstance(batch[0][1][0], list | tuple):
-            num_targets = len(batch[0][1][0])
-            y_batch = []
-            for i in range(num_targets):
-                target_tensors = [sample_y[0][i] for _, sample_y in batch]
-                stacked_target = torch.stack(target_tensors)
-                y_batch.append(stacked_target)
-        else:
-            y_batch = torch.stack([y[0] for _, y in batch])
+        num_targets = len(batch[0][1][0])
+        y_batch = []
+        for i in range(num_targets):
+            target_tensors = [sample_y[0][i] for _, sample_y in batch]
+            stacked_target = torch.stack(target_tensors)
+            y_batch.append(stacked_target)
 
         weight_batch = torch.stack([sample_y[1] for _, sample_y in batch])
 

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -386,9 +386,10 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         weights = sample.get("weights", None)
 
         target = target.float()
+        features = features.float()
+
         if target.ndim == 1:
             target = target.unsqueeze(-1)
-        features = features.float()
         if weights is not None:
             weights = weights.float()
 

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -389,7 +389,8 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         if target.ndim == 1:
             target = target.unsqueeze(-1)
         features = features.float()
-        weights = weights.float()
+        if weights is not None:
+            weights = weights.float()
 
         time_mask = torch.tensor(times <= cutoff_time, dtype=torch.bool)
         return target, features, times, time_mask, weights

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -1126,17 +1126,6 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             "encoder_mask": torch.stack([x["encoder_mask"] for x, _ in batch]),
             "decoder_mask": torch.stack([x["decoder_mask"] for x, _ in batch]),
         }
-        if isinstance(batch[0][0]["target_scale"], list | tuple):
-            num_targets = len(batch[0][0]["target_scale"])
-            target_scale = [
-                torch.stack([x["target_scale"][i] for x, _ in batch])
-                for i in range(num_targets)
-            ]
-        else:
-            target_scale = torch.stack([x["target_scale"] for x, _ in batch])
-
-        x_batch["target_scale"] = target_scale
-
         num_targets = len(batch[0][0]["target_scale"])
         target_scale = [
             torch.stack([x["target_scale"][i] for x, _ in batch])

--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -60,7 +60,7 @@ class _TslibDataset(Dataset):
     def __len__(self) -> int:
         return len(self.windows)
 
-    def __getitem__(self, idx: int) -> dict[str, Any]:
+    def __getitem__(self, idx: int):
         """
         Get the processed dataset item at the given index.
 
@@ -224,6 +224,12 @@ class _TslibDataset(Dataset):
 
         if "target_scale" in processed_data:
             x["target_scale"] = processed_data["target_scale"]
+        weights = processed_data.get("weights", None)
+        future_weight = (
+            weights[future_indices]
+            if weights is not None
+            else torch.ones(prediction_length, dtype=torch.float32)
+        )
 
         y = processed_data["target"][future_indices]
         if self.data_module.n_targets > 1:
@@ -231,7 +237,7 @@ class _TslibDataset(Dataset):
         else:
             y = y.squeeze(-1)
 
-        return x, y
+        return x, (y, future_weight)
 
 
 class TslibDataModule(LightningDataModule):
@@ -566,6 +572,7 @@ class TslibDataModule(LightningDataModule):
         features = series["x"]
         timestep = series["t"]
         cutoff_time = series["cutoff_time"]
+        weights = series.get("weights", None)
 
         mask_timestep = torch.tensor(timestep <= cutoff_time, dtype=torch.bool)
 
@@ -578,6 +585,10 @@ class TslibDataModule(LightningDataModule):
             features = features.detach().clone().float()
         else:
             features = torch.tensor(features, dtype=torch.float32)
+        if isinstance(weights, torch.Tensor):
+            weights = weights.float()
+        elif weights is not None:
+            weights = torch.tensor(weights, dtype=torch.float32)
 
         # scaling and normalization
         target_scale = {}
@@ -600,6 +611,7 @@ class TslibDataModule(LightningDataModule):
                 "continuous": continuous_features,
             },
             "target": target,
+            "weights": weights,
             "static": series["st"],
             "group": series.get("group", torch.tensor([0])),
             "length": len(series),
@@ -880,13 +892,14 @@ class TslibDataModule(LightningDataModule):
                 [x["static_continuous_features"] for x, _ in batch]
             )
 
-        if isinstance(batch[0][1], list | tuple):
-            num_targets = len(batch[0][1])
+        if isinstance(batch[0][1][0], list | tuple):
+            num_targets = len(batch[0][1][0])
             y_batch = []
             for i in range(num_targets):
-                target_tensors = [sample_y[i] for _, sample_y in batch]
+                target_tensors = [sample_y[0][i] for _, sample_y in batch]
                 stacked_target = torch.stack(target_tensors)
                 y_batch.append(stacked_target)
         else:
-            y_batch = torch.stack([y for _, y in batch])
-        return x_batch, y_batch
+            y_batch = torch.stack([sample_y[0] for _, sample_y in batch])
+        weight_batch = torch.stack([sample_y[1] for _, sample_y in batch])
+        return x_batch, (y_batch, weight_batch)

--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -232,10 +232,7 @@ class _TslibDataset(Dataset):
         )
 
         y = processed_data["target"][future_indices]
-        if self.data_module.n_targets > 1:
-            y = [t.squeeze(-1) for t in torch.split(y, 1, dim=1)]
-        else:
-            y = y.squeeze(-1)
+        y = [t.squeeze(-1) for t in torch.split(y, 1, dim=1)]
 
         return x, (y, future_weight)
 
@@ -892,14 +889,12 @@ class TslibDataModule(LightningDataModule):
                 [x["static_continuous_features"] for x, _ in batch]
             )
 
-        if isinstance(batch[0][1][0], list | tuple):
-            num_targets = len(batch[0][1][0])
-            y_batch = []
-            for i in range(num_targets):
-                target_tensors = [sample_y[0][i] for _, sample_y in batch]
-                stacked_target = torch.stack(target_tensors)
-                y_batch.append(stacked_target)
-        else:
-            y_batch = torch.stack([sample_y[0] for _, sample_y in batch])
+        num_targets = len(batch[0][1][0])
+        y_batch = []
+        for i in range(num_targets):
+            target_tensors = [sample_y[0][i] for _, sample_y in batch]
+            stacked_target = torch.stack(target_tensors)
+            y_batch.append(stacked_target)
+
         weight_batch = torch.stack([sample_y[1] for _, sample_y in batch])
         return x_batch, (y_batch, weight_batch)

--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -582,10 +582,8 @@ class TslibDataModule(LightningDataModule):
             features = features.detach().clone().float()
         else:
             features = torch.tensor(features, dtype=torch.float32)
-        if isinstance(weights, torch.Tensor):
+        if weights is not None:
             weights = weights.float()
-        elif weights is not None:
-            weights = torch.tensor(weights, dtype=torch.float32)
 
         # scaling and normalization
         target_scale = {}

--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -225,11 +225,7 @@ class _TslibDataset(Dataset):
         if "target_scale" in processed_data:
             x["target_scale"] = processed_data["target_scale"]
         weights = processed_data.get("weights", None)
-        future_weight = (
-            weights[future_indices]
-            if weights is not None
-            else torch.ones(prediction_length, dtype=torch.float32)
-        )
+        future_weight = weights[future_indices] if weights is not None else None
 
         y = processed_data["target"][future_indices]
         y = [t.squeeze(-1) for t in torch.split(y, 1, dim=1)]
@@ -894,5 +890,6 @@ class TslibDataModule(LightningDataModule):
             stacked_target = torch.stack(target_tensors)
             y_batch.append(stacked_target)
 
-        weight_batch = torch.stack([sample_y[1] for _, sample_y in batch])
+        weights = [sample_y[1] for _, sample_y in batch]
+        weight_batch = None if weights[0] is None else torch.stack(weights)
         return x_batch, (y_batch, weight_batch)

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -160,18 +160,63 @@ class BaseModel(LightningModule):
 
         return predict_callback.result
 
-    def to_prediction(self, out: dict[str, Any], **kwargs) -> torch.Tensor:
-        """Converts raw model output to point forecasts."""
-        # todo: add MultiLoss support
+    def to_prediction(
+        self, out: dict[str, Any], use_metric: bool = True, **kwargs
+    ) -> list[torch.Tensor] | torch.Tensor:
+        """Converts raw model output to point forecasts.
+
+        Parameters
+        ----------
+        out : dict
+            Network output dict with key ``"prediction"``.
+        use_metric : bool
+            If True, use loss metric for conversion.
+            If False, take mean over prediction directly.
+        """
+        if not use_metric:
+            if isinstance(self.loss, MultiLoss):
+                return [
+                    Metric.to_prediction(loss, out["prediction"][idx])
+                    for idx, loss in enumerate(self.loss)
+                ]
+            else:
+                return Metric.to_prediction(self.loss, out["prediction"])
         try:
             out = self.loss.to_prediction(out["prediction"], **kwargs)
         except TypeError:  # in case passed kwargs do not exist
             out = self.loss.to_prediction(out["prediction"])
         return out
 
-    def to_quantiles(self, out: dict[str, Any], **kwargs) -> torch.Tensor:
-        """Converts raw model output to quantile forecasts."""
-        # todo: add MultiLoss support
+    def to_quantiles(
+        self, out: dict[str, Any], use_metric: bool = True, **kwargs
+    ) -> list[torch.Tensor] | torch.Tensor:
+        """Converts raw model output to quantile forecasts.
+
+        Parameters
+        ----------
+        out : dict
+            Network output dict.
+        use_metric : bool
+            If True, use loss metric for conversion.
+            If False, take mean over prediction directly.
+        """
+
+        if not use_metric:
+            if isinstance(self.loss, MultiLoss):
+                return [
+                    Metric.to_quantiles(
+                        loss,
+                        out["prediction"][idx],
+                        quantiles=kwargs.get("quantiles", loss.quantiles),
+                    )
+                    for idx, loss in enumerate(self.loss)
+                ]
+            else:
+                return Metric.to_quantiles(
+                    self.loss,
+                    out["prediction"],
+                    quantiles=kwargs.get("quantiles", self.loss.quantiles),
+                )
         try:
             out = self.loss.to_quantiles(out["prediction"], **kwargs)
         except TypeError:  # in case passed kwargs do not exist
@@ -379,13 +424,23 @@ class BaseModel(LightningModule):
         prefix : str
             Prefix for the logged metrics (e.g., "train", "val", "test").
         """
+        if not self.logging_metrics:
+            return
+
+        target, weight = y
+        is_multi = isinstance(target, list)
+        y_hat_list = y_hat if is_multi else [y_hat]
+        target_list = target if is_multi else [target]
+
         for metric in self.logging_metrics:
-            metric_value = metric(y_hat, y)
-            self.log(
-                f"{prefix}_{metric.__class__.__name__}",
-                metric_value,
-                on_step=False,
-                on_epoch=True,
-                prog_bar=True,
-                logger=True,
-            )
+            for idx, (yh, yt) in enumerate(zip(y_hat_list, target_list)):
+                metric_value = metric(yh, (yt, weight))
+                tag = f"target{idx}_" if is_multi else ""
+                self.log(
+                    f"{tag}{prefix}_{metric.__class__.__name__}",
+                    metric_value,
+                    on_step=False,
+                    on_epoch=True,
+                    prog_bar=True,
+                    logger=True,
+                )

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -179,21 +179,19 @@ class BaseModel(LightningModule):
             If True, use loss metric for conversion.
             If False, take mean over prediction directly.
         """
-        pred = out["prediction"]
-        pred_list = pred if isinstance(pred, (list, tuple)) else [pred]
-        pred_input = pred_list[0] if len(pred_list) == 1 else pred_list
+        pred = self._coerce_y_hat_for_loss(out["prediction"])
 
         if not use_metric:
             if isinstance(self.loss, MultiLoss):
                 return [
-                    getattr(Metric, metric_fn_name)(loss, pred_list[idx], **kwargs)
-                    for idx, loss in enumerate(self.loss)
+                    getattr(Metric, metric_fn_name)(sub_loss, pred[idx], **kwargs)
+                    for idx, sub_loss in enumerate(self.loss)
                 ]
-            pred_out = getattr(Metric, metric_fn_name)(self.loss, pred_input, **kwargs)
+            pred_out = getattr(Metric, metric_fn_name)(self.loss, pred, **kwargs)
             return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
 
         bound_fn = getattr(self.loss, metric_fn_name)
-        pred_out = bound_fn(pred_input, **kwargs) if kwargs else bound_fn(pred_input)
+        pred_out = bound_fn(pred, **kwargs) if kwargs else bound_fn(pred)
         return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
 
     def to_prediction(
@@ -229,20 +227,67 @@ class BaseModel(LightningModule):
         return self._convert_output(out, "to_quantiles", use_metric, **kwargs)
 
     def _coerce_targets_for_loss(self, y):
-        """
-        Coerce target outputs to match loss function expectations.
-        """
+        """Coerce target outputs to match loss function expectations."""
         y_targets, y_weights = y
-        if isinstance(y_targets, list) and len(y_targets) == 1:
-            return y_targets[0], y_weights
-        return y_targets, y_weights
+        if not isinstance(y_targets, (list, tuple)):
+            y_targets = [y_targets]
+        n_targets = len(y_targets)
+
+        if isinstance(self.loss, MultiLoss):
+            if len(self.loss) != n_targets:
+                raise ValueError(
+                    f"MultiLoss holds {len(self.loss)} metrics but the data "
+                    f"provides {n_targets} target(s) - these have to match."
+                )
+            return list(y_targets), y_weights
+
+        if n_targets > 1:
+            raise ValueError(
+                f"The data provides {n_targets} targets, which requires the loss "
+                f"to be a MultiLoss, but found {self.loss.__class__.__name__}. "
+                f"Use MultiLoss([...]) with one metric per target."
+            )
+        return y_targets[0], y_weights
+
+    def _coerce_y_hat_for_loss(self, y_hat):
+        """Coerce the network output to match loss function expectations."""
+        if not isinstance(self.loss, MultiLoss):
+            if isinstance(y_hat, (list, tuple)):
+                if len(y_hat) != 1:
+                    raise ValueError(
+                        f"The model returned {len(y_hat)} predictions, which "
+                        f"requires the loss to be a MultiLoss, but found "
+                        f"{self.loss.__class__.__name__}."
+                    )
+                return y_hat[0]
+            return y_hat
+
+        n_metrics = len(self.loss)
+        if isinstance(y_hat, (list, tuple)):
+            if len(y_hat) != n_metrics:
+                raise ValueError(
+                    f"MultiLoss holds {n_metrics} metrics but the model returned "
+                    f"{len(y_hat)} predictions - these have to match."
+                )
+            return list(y_hat)
+
+        if n_metrics == 1:
+            return [y_hat]
+        if y_hat.size(-1) != n_metrics:
+            raise ValueError(
+                f"MultiLoss holds {n_metrics} metrics, so the model has to return "
+                f"one prediction per target, either as a list or as a tensor whose "
+                f"last dimension is {n_metrics}, but got shape "
+                f"{tuple(y_hat.shape)}."
+            )
+        return list(torch.split(y_hat, 1, dim=-1))
 
     def _step(self, batch, batch_idx):
         """Shared step logic for train, val, and test."""
         x, y = batch
         y = self._coerce_targets_for_loss(y)
         y_hat_dict = self(x)
-        y_hat = y_hat_dict["prediction"]
+        y_hat = self._coerce_y_hat_for_loss(y_hat_dict["prediction"])
         loss = self.loss(y_hat, y)
         return {"loss": loss, "y_hat": y_hat, "y": y}
 
@@ -295,11 +340,7 @@ class BaseModel(LightningModule):
             Predicted output tensor.
         """
         x, _ = batch
-        y_hat = self(x)
-        pred = y_hat["prediction"]
-        if not isinstance(pred, (list, tuple)):
-            y_hat["prediction"] = [pred]
-        return y_hat
+        return self(x)
 
     def configure_optimizers(self) -> dict:
         """
@@ -395,7 +436,8 @@ class BaseModel(LightningModule):
             return
 
         target, weight = y
-        is_multi = isinstance(target, list)
+
+        is_multi = isinstance(self.loss, MultiLoss)
         y_hat_list = y_hat if is_multi else [y_hat]
         target_list = target if is_multi else [target]
 

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -223,89 +223,50 @@ class BaseModel(LightningModule):
             out = self.loss.to_quantiles(out["prediction"])
         return out
 
-    def training_step(
-        self, batch: tuple[dict[str, torch.Tensor]], batch_idx: int
-    ) -> STEP_OUTPUT:
+    def _coerce_targets_for_loss(self, y):
         """
-        Training step for the model.
-
-        Parameters
-        ----------
-        batch : Tuple[Dict[str, torch.Tensor]]
-            Batch of data containing input and target tensors.
-        batch_idx : int
-            Index of the batch.
-
-        Returns
-        -------
-        STEP_OUTPUT
-            Dictionary containing the loss and other metrics.
+        Coerce target outputs to match loss function expectations.
+        The DataModule always returns a list of tensors (one per target),
+        but legacy metrics/losses expect a single tensor for single-target tasks.
         """
+        y_targets, y_weights = y
+        if isinstance(y_targets, list) and len(y_targets) == 1:
+            return y_targets[0], y_weights
+        return y_targets, y_weights
+
+    def _step(self, batch, batch_idx):
+        """Shared step logic for train, val, and test."""
         x, y = batch
+        y = self._coerce_targets_for_loss(y)
         y_hat_dict = self(x)
         y_hat = y_hat_dict["prediction"]
         loss = self.loss(y_hat, y)
+        return {"loss": loss, "y_hat": y_hat, "y": y}
+
+    def training_step(self, batch, batch_idx):
+        step_out = self._step(batch, batch_idx)
+
         self.log(
-            "train_loss", loss, on_step=True, on_epoch=True, prog_bar=True, logger=True
+            "train_loss", step_out["loss"], on_step=True, on_epoch=True, prog_bar=True
         )
-        self.log_metrics(y_hat, y, prefix="train")
-        return {"loss": loss}
+        self.log_metrics(step_out["y_hat"], step_out["y"], prefix="train")
+        return step_out["loss"]
 
-    def validation_step(
-        self, batch: tuple[dict[str, torch.Tensor]], batch_idx: int
-    ) -> STEP_OUTPUT:
-        """
-        Validation step for the model.
+    def validation_step(self, batch, batch_idx):
+        step_out = self._step(batch, batch_idx)
 
-        Parameters
-        ----------
-        batch : Tuple[Dict[str, torch.Tensor]]
-            Batch of data containing input and target tensors.
-        batch_idx : int
-            Index of the batch.
-
-        Returns
-        -------
-        STEP_OUTPUT
-            Dictionary containing the loss and other metrics.
-        """
-        x, y = batch
-        y_hat_dict = self(x)
-        y_hat = y_hat_dict["prediction"]
-        loss = self.loss(y_hat, y)
         self.log(
-            "val_loss", loss, on_step=False, on_epoch=True, prog_bar=True, logger=True
+            "val_loss", step_out["loss"], on_step=False, on_epoch=True, prog_bar=True
         )
-        self.log_metrics(y_hat, y, prefix="val")
-        return {"val_loss": loss}
+        self.log_metrics(step_out["y_hat"], step_out["y"], prefix="val")
+        return step_out
 
-    def test_step(
-        self, batch: tuple[dict[str, torch.Tensor]], batch_idx: int
-    ) -> STEP_OUTPUT:
-        """
-        Test step for the model.
+    def test_step(self, batch, batch_idx):
+        step_out = self._step(batch, batch_idx)
 
-        Parameters
-        ----------
-        batch : Tuple[Dict[str, torch.Tensor]]
-            Batch of data containing input and target tensors.
-        batch_idx : int
-            Index of the batch.
-
-        Returns
-        -------
-        STEP_OUTPUT
-            Dictionary containing the loss and other metrics.
-        """
-        x, y = batch
-        y_hat_dict = self(x)
-        y_hat = y_hat_dict["prediction"]
-        loss = self.loss(y_hat, y)
-        self.log(
-            "test_loss", loss, on_step=False, on_epoch=True, prog_bar=True, logger=True
-        )
-        self.log_metrics(y_hat, y, prefix="test")
-        return {"test_loss": loss}
+        self.log("test_loss", step_out["loss"], on_step=False, on_epoch=True)
+        self.log_metrics(step_out["y_hat"], step_out["y"], prefix="test")
+        return step_out
 
     def predict_step(
         self,

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -160,6 +160,42 @@ class BaseModel(LightningModule):
 
         return predict_callback.result
 
+    def _convert_output(
+        self,
+        out: dict[str, Any],
+        metric_fn_name: str,
+        use_metric: bool = False,
+        **kwargs,
+    ) -> list[torch.Tensor]:
+        """Convert inputs for prediction/quantiles.
+
+        Parameters
+        ----------
+        out : dict
+            Network output dict with key "prediction".
+        metric_fn_name : str
+            Name of the Metric method to invoke: "to_prediction" or "to_quantiles".
+        use_metric : bool, default = False
+            If True, use loss metric for conversion.
+            If False, take mean over prediction directly.
+        """
+        pred = out["prediction"]
+        pred_list = pred if isinstance(pred, (list, tuple)) else [pred]
+        pred_input = pred_list[0] if len(pred_list) == 1 else pred_list
+
+        if not use_metric:
+            if isinstance(self.loss, MultiLoss):
+                return [
+                    getattr(Metric, metric_fn_name)(loss, pred_list[idx], **kwargs)
+                    for idx, loss in enumerate(self.loss)
+                ]
+            pred_out = getattr(Metric, metric_fn_name)(self.loss, pred_input, **kwargs)
+            return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
+
+        bound_fn = getattr(self.loss, metric_fn_name)
+        pred_out = bound_fn(pred_input, **kwargs) if kwargs else bound_fn(pred_input)
+        return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
+
     def to_prediction(
         self, out: dict[str, Any], use_metric: bool = False, **kwargs
     ) -> list[torch.Tensor] | torch.Tensor:
@@ -173,23 +209,7 @@ class BaseModel(LightningModule):
             If True, use loss metric for conversion.
             If False, take mean over prediction directly.
         """
-        pred = out["prediction"]
-        pred_list = pred if isinstance(pred, (list, tuple)) else [pred]
-        pred_input = pred_list[0] if len(pred_list) == 1 else pred_list
-        if not use_metric:
-            if isinstance(self.loss, MultiLoss):
-                return [
-                    Metric.to_prediction(loss, pred_list[idx])
-                    for idx, loss in enumerate(self.loss)
-                ]
-            else:
-                pred_out = Metric.to_prediction(self.loss, pred_input)
-                return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
-        if kwargs:
-            pred_out = self.loss.to_prediction(pred_input, **kwargs)
-        else:  # in case passed kwargs do not exist
-            pred_out = self.loss.to_prediction(pred_input)
-        return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
+        return self._convert_output(out, "to_prediction", use_metric, **kwargs)
 
     def to_quantiles(
         self, out: dict[str, Any], use_metric: bool = False, **kwargs
@@ -204,31 +224,9 @@ class BaseModel(LightningModule):
             If True, use loss metric for conversion.
             If False, take mean over prediction directly.
         """
-        pred = out["prediction"]
-        pred_list = pred if isinstance(pred, (list, tuple)) else [pred]
-        pred_input = pred_list[0] if len(pred_list) == 1 else pred_list
         if not use_metric:
-            if isinstance(self.loss, MultiLoss):
-                return [
-                    Metric.to_quantiles(
-                        loss,
-                        pred_list[idx],
-                        quantiles=kwargs.get("quantiles", loss.quantiles),
-                    )
-                    for idx, loss in enumerate(self.loss)
-                ]
-            else:
-                pred_out = Metric.to_quantiles(
-                    self.loss,
-                    pred_input,
-                    quantiles=kwargs.get("quantiles", self.loss.quantiles),
-                )
-                return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
-        if kwargs:
-            pred_out = self.loss.to_quantiles(pred_input, **kwargs)
-        else:  # in case passed kwargs do not exist
-            pred_out = self.loss.to_quantiles(pred_input)
-        return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
+            kwargs.setdefault("quantiles", self.loss.quantiles)
+        return self._convert_output(out, "to_quantiles", use_metric, **kwargs)
 
     def _coerce_targets_for_loss(self, y):
         """

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -233,8 +233,6 @@ class BaseModel(LightningModule):
     def _coerce_targets_for_loss(self, y):
         """
         Coerce target outputs to match loss function expectations.
-        The DataModule always returns a list of tensors (one per target),
-        but legacy metrics/losses expect a single tensor for single-target tasks.
         """
         y_targets, y_weights = y
         if isinstance(y_targets, list) and len(y_targets) == 1:

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -206,6 +206,8 @@ class BaseModel(LightningModule):
         use_metric : bool, default = False
             If True, use loss metric for conversion.
             If False, take mean over prediction directly.
+        **kwargs
+            Passed on to the metric's ``to_prediction``.
         """
         return self._convert_output(out, "to_prediction", use_metric, **kwargs)
 
@@ -221,9 +223,9 @@ class BaseModel(LightningModule):
         use_metric : bool, default = False
             If True, use loss metric for conversion.
             If False, take mean over prediction directly.
+        **kwargs
+            Passed on to the metric's ``to_quantiles``.
         """
-        if not use_metric:
-            kwargs.setdefault("quantiles", self.loss.quantiles)
         return self._convert_output(out, "to_quantiles", use_metric, **kwargs)
 
     def _coerce_targets_for_loss(self, y):

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -161,7 +161,7 @@ class BaseModel(LightningModule):
         return predict_callback.result
 
     def to_prediction(
-        self, out: dict[str, Any], use_metric: bool = True, **kwargs
+        self, out: dict[str, Any], use_metric: bool = False, **kwargs
     ) -> list[torch.Tensor] | torch.Tensor:
         """Converts raw model output to point forecasts.
 
@@ -169,26 +169,29 @@ class BaseModel(LightningModule):
         ----------
         out : dict
             Network output dict with key ``"prediction"``.
-        use_metric : bool
+        use_metric : bool, default = False
             If True, use loss metric for conversion.
             If False, take mean over prediction directly.
         """
+        pred = out["prediction"]
+        pred_list = pred if isinstance(pred, (list, tuple)) else [pred]
+        pred_input = pred_list[0] if len(pred_list) == 1 else pred_list
         if not use_metric:
             if isinstance(self.loss, MultiLoss):
                 return [
-                    Metric.to_prediction(loss, out["prediction"][idx])
+                    Metric.to_prediction(loss, pred_list[idx])
                     for idx, loss in enumerate(self.loss)
                 ]
             else:
-                return Metric.to_prediction(self.loss, out["prediction"])
-        try:
-            out = self.loss.to_prediction(out["prediction"], **kwargs)
-        except TypeError:  # in case passed kwargs do not exist
-            out = self.loss.to_prediction(out["prediction"])
+                return Metric.to_prediction(self.loss, pred_input)
+        if kwargs:
+            out = self.loss.to_prediction(pred_input, **kwargs)
+        else:  # in case passed kwargs do not exist
+            out = self.loss.to_prediction(pred_input)
         return out
 
     def to_quantiles(
-        self, out: dict[str, Any], use_metric: bool = True, **kwargs
+        self, out: dict[str, Any], use_metric: bool = False, **kwargs
     ) -> list[torch.Tensor] | torch.Tensor:
         """Converts raw model output to quantile forecasts.
 
@@ -196,17 +199,19 @@ class BaseModel(LightningModule):
         ----------
         out : dict
             Network output dict.
-        use_metric : bool
+        use_metric : bool, default = False
             If True, use loss metric for conversion.
             If False, take mean over prediction directly.
         """
-
+        pred = out["prediction"]
+        pred_list = pred if isinstance(pred, (list, tuple)) else [pred]
+        pred_input = pred_list[0] if len(pred_list) == 1 else pred_list
         if not use_metric:
             if isinstance(self.loss, MultiLoss):
                 return [
                     Metric.to_quantiles(
                         loss,
-                        out["prediction"][idx],
+                        pred_list[idx],
                         quantiles=kwargs.get("quantiles", loss.quantiles),
                     )
                     for idx, loss in enumerate(self.loss)
@@ -214,13 +219,13 @@ class BaseModel(LightningModule):
             else:
                 return Metric.to_quantiles(
                     self.loss,
-                    out["prediction"],
+                    pred_input,
                     quantiles=kwargs.get("quantiles", self.loss.quantiles),
                 )
-        try:
-            out = self.loss.to_quantiles(out["prediction"], **kwargs)
-        except TypeError:  # in case passed kwargs do not exist
-            out = self.loss.to_quantiles(out["prediction"])
+        if kwargs:
+            out = self.loss.to_quantiles(pred_input, **kwargs)
+        else:  # in case passed kwargs do not exist
+            out = self.loss.to_quantiles(pred_input)
         return out
 
     def _coerce_targets_for_loss(self, y):
@@ -293,6 +298,9 @@ class BaseModel(LightningModule):
         """
         x, _ = batch
         y_hat = self(x)
+        pred = y_hat["prediction"]
+        if not isinstance(pred, (list, tuple)):
+            y_hat["prediction"] = [pred]
         return y_hat
 
     def configure_optimizers(self) -> dict:

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -183,12 +183,13 @@ class BaseModel(LightningModule):
                     for idx, loss in enumerate(self.loss)
                 ]
             else:
-                return Metric.to_prediction(self.loss, pred_input)
+                pred_out = Metric.to_prediction(self.loss, pred_input)
+                return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
         if kwargs:
-            out = self.loss.to_prediction(pred_input, **kwargs)
+            pred_out = self.loss.to_prediction(pred_input, **kwargs)
         else:  # in case passed kwargs do not exist
-            out = self.loss.to_prediction(pred_input)
-        return out
+            pred_out = self.loss.to_prediction(pred_input)
+        return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
 
     def to_quantiles(
         self, out: dict[str, Any], use_metric: bool = False, **kwargs
@@ -217,16 +218,17 @@ class BaseModel(LightningModule):
                     for idx, loss in enumerate(self.loss)
                 ]
             else:
-                return Metric.to_quantiles(
+                pred_out = Metric.to_quantiles(
                     self.loss,
                     pred_input,
                     quantiles=kwargs.get("quantiles", self.loss.quantiles),
                 )
+                return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
         if kwargs:
-            out = self.loss.to_quantiles(pred_input, **kwargs)
+            pred_out = self.loss.to_quantiles(pred_input, **kwargs)
         else:  # in case passed kwargs do not exist
-            out = self.loss.to_quantiles(pred_input)
-        return out
+            pred_out = self.loss.to_quantiles(pred_input)
+        return pred_out if isinstance(pred_out, (list, tuple)) else [pred_out]
 
     def _coerce_targets_for_loss(self, y):
         """

--- a/pytorch_forecasting/models/base/_tslib_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_tslib_base_model_v2.py
@@ -147,10 +147,6 @@ class TslibBaseModel(BaseModel):
 
         if "target" in x:
             y_hat["target"] = x["target"]
-        pred = y_hat["prediction"]
-
-        if not isinstance(pred, (list, tuple)):
-            y_hat["prediction"] = [pred]
         return y_hat
 
     def transform_output(

--- a/pytorch_forecasting/models/base/_tslib_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_tslib_base_model_v2.py
@@ -147,7 +147,10 @@ class TslibBaseModel(BaseModel):
 
         if "target" in x:
             y_hat["target"] = x["target"]
+        pred = y_hat["prediction"]
 
+        if not isinstance(pred, (list, tuple)):
+            y_hat["prediction"] = [pred]
         return y_hat
 
     def transform_output(

--- a/pytorch_forecasting/tests/test_all_v2/_test_integration.py
+++ b/pytorch_forecasting/tests/test_all_v2/_test_integration.py
@@ -23,7 +23,7 @@ def _integration(
     assert isinstance(predictions, dict)
     assert "prediction" in predictions
 
-    pred_tensor = predictions["prediction"]
+    pred_tensor = predictions["prediction"][0]
     assert isinstance(pred_tensor, torch.Tensor)
     assert pred_tensor.ndim == 3, f"Prediction must be 3D, got {pred_tensor.ndim}D"
 

--- a/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
+++ b/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
@@ -81,7 +81,7 @@ class TestAllPtForecastersV2(EstimatorPackageConfig, EstimatorFixtureGenerator):
         # mode="raw"
         raw_out = pkg.predict(predict_data, mode="raw")
         raw_pred_tensor = raw_out["prediction"][0]
-        assert any(isinstance(v, torch.Tensor) for v in raw_out.values())
+        assert any(isinstance(v[0], torch.Tensor) for v in raw_out.values())
         assert (
             raw_pred_tensor.ndim == 3
         ), f"Prediction must be 3D, got {raw_pred_tensor.ndim}D"

--- a/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
+++ b/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
@@ -80,7 +80,7 @@ class TestAllPtForecastersV2(EstimatorPackageConfig, EstimatorFixtureGenerator):
 
         # mode="raw"
         raw_out = pkg.predict(predict_data, mode="raw")
-        raw_pred_tensor = raw_out["prediction"]
+        raw_pred_tensor = raw_out["prediction"][0]
         assert any(isinstance(v, torch.Tensor) for v in raw_out.values())
         assert (
             raw_pred_tensor.ndim == 3
@@ -88,7 +88,7 @@ class TestAllPtForecastersV2(EstimatorPackageConfig, EstimatorFixtureGenerator):
 
         # mode="quantiles"
         quantile_out = pkg.predict(predict_data, mode="quantiles")
-        quanitle_pred_tensor = quantile_out["prediction"]
+        quanitle_pred_tensor = quantile_out["prediction"][0]
         assert isinstance(quanitle_pred_tensor, torch.Tensor)
         assert (
             quanitle_pred_tensor.ndim == 3
@@ -96,7 +96,7 @@ class TestAllPtForecastersV2(EstimatorPackageConfig, EstimatorFixtureGenerator):
 
         # mode="prediction"
         pred_out = pkg.predict(predict_data, mode="prediction")
-        pred_tensor = pred_out["prediction"]
+        pred_tensor = pred_out["prediction"][0]
         assert isinstance(pred_tensor, torch.Tensor)
         assert pred_tensor.ndim == 2, f"Prediction must be 3D, got {pred_tensor.ndim}D"
 

--- a/tests/test_data/test_data_module.py
+++ b/tests/test_data/test_data_module.py
@@ -238,8 +238,7 @@ def test_processed_dataset(data_module):
 
     assert x["decoder_cat"].shape[1] == known_cat_count
     assert x["decoder_cont"].shape[1] == known_cont_count
-
-    assert y.shape[0] == data_module.max_prediction_length
+    assert y[0].shape[0] == data_module.max_prediction_length
 
 
 def test_collate_fn(data_module):
@@ -277,8 +276,8 @@ def test_collate_fn(data_module):
 
     assert x_batch["decoder_cat"].shape[2] == known_cat_count
     assert x_batch["decoder_cont"].shape[2] == known_cont_count
-    assert y_batch.shape[0] == batch_size
-    assert y_batch.shape[1] == data_module.max_prediction_length
+    assert y_batch[0].shape[0] == batch_size
+    assert y_batch[0].shape[1] == data_module.max_prediction_length
 
 
 def test_full_dataloader_iteration(data_module):
@@ -317,8 +316,8 @@ def test_full_dataloader_iteration(data_module):
     assert x_batch["decoder_cat"].shape[2] == known_cat_count
     assert x_batch["decoder_cont"].shape[0] == data_module.batch_size
     assert x_batch["decoder_cont"].shape[2] == known_cont_count
-    assert y_batch.shape[0] == data_module.batch_size
-    assert y_batch.shape[1] == data_module.max_prediction_length
+    assert y_batch[0].shape[0] == data_module.batch_size
+    assert y_batch[0].shape[1] == data_module.max_prediction_length
 
 
 def test_variable_encoder_lengths(sample_timeseries_data):

--- a/tests/test_data/test_data_module.py
+++ b/tests/test_data/test_data_module.py
@@ -493,8 +493,8 @@ def test_multivariate_target(normalizer_list):
 
     x, y = dm.train_dataset[0]
     assert len(y) == 2
-    assert y[0].shape == (dm.max_prediction_length,)
-    assert y[1].shape == (dm.max_prediction_length,)
+    assert y[0][0].shape == (dm.max_prediction_length,)
+    assert y[0][1].shape == (dm.max_prediction_length,)
     assert x["target_past"].shape == (dm.max_encoder_length, 2)
     if normalizer_list is None:
         dm._target_normalizer = None
@@ -616,7 +616,7 @@ def test_target_normalizers(sample_timeseries_data, normalizer):
 
     x_no_norm, y_no_norm = dm_no_norm.train_dataset[0]
     x_with_norm, y_with_norm = dm_with_norm.train_dataset[0]
-    assert y_with_norm.shape == y_no_norm.shape
+    assert y_with_norm[0][0].shape == y_no_norm[0][0].shape
     assert x_with_norm["target_past"].shape == x_no_norm["target_past"].shape
 
     if normalizer is not None and not isinstance(normalizer, EncoderNormalizer):

--- a/tests/test_data/test_data_module.py
+++ b/tests/test_data/test_data_module.py
@@ -238,7 +238,7 @@ def test_processed_dataset(data_module):
 
     assert x["decoder_cat"].shape[1] == known_cat_count
     assert x["decoder_cont"].shape[1] == known_cont_count
-    assert y[0].shape[0] == data_module.max_prediction_length
+    assert y[0][0].shape[0] == data_module.max_prediction_length
 
 
 def test_collate_fn(data_module):
@@ -253,7 +253,10 @@ def test_collate_fn(data_module):
     x_batch, y_batch = data_module.collate_fn(batch)
 
     for key in x_batch:
-        assert x_batch[key].shape[0] == batch_size
+        if isinstance(x_batch[key], list):
+            assert x_batch[key][0].shape[0] == batch_size
+        else:
+            assert x_batch[key].shape[0] == batch_size
 
     metadata = data_module.time_series_metadata
     known_cat_count = len(
@@ -276,8 +279,8 @@ def test_collate_fn(data_module):
 
     assert x_batch["decoder_cat"].shape[2] == known_cat_count
     assert x_batch["decoder_cont"].shape[2] == known_cont_count
-    assert y_batch[0].shape[0] == batch_size
-    assert y_batch[0].shape[1] == data_module.max_prediction_length
+    assert y_batch[0][0].shape[0] == batch_size
+    assert y_batch[0][0].shape[1] == data_module.max_prediction_length
 
 
 def test_full_dataloader_iteration(data_module):
@@ -316,8 +319,8 @@ def test_full_dataloader_iteration(data_module):
     assert x_batch["decoder_cat"].shape[2] == known_cat_count
     assert x_batch["decoder_cont"].shape[0] == data_module.batch_size
     assert x_batch["decoder_cont"].shape[2] == known_cont_count
-    assert y_batch[0].shape[0] == data_module.batch_size
-    assert y_batch[0].shape[1] == data_module.max_prediction_length
+    assert y_batch[0][0].shape[0] == data_module.batch_size
+    assert y_batch[0][0].shape[1] == data_module.max_prediction_length
 
 
 def test_variable_encoder_lengths(sample_timeseries_data):

--- a/tests/test_models/test_tft_v2.py
+++ b/tests/test_models/test_tft_v2.py
@@ -368,7 +368,6 @@ def test_model_with_datamodule_integration(
 
     actual_batch_size = batch_x["encoder_cont"].shape[0]
     batch_x = {k: v.to(device) for k, v in batch_x.items()}
-    batch_y = batch_y.to(device)
 
     assert batch_x["encoder_cont"].shape[2] == model_metadata_from_dm["encoder_cont"]
     assert batch_x["encoder_cat"].shape[2] == model_metadata_from_dm["encoder_cat"]
@@ -391,7 +390,7 @@ def test_model_with_datamodule_integration(
         model_metadata_from_dm["target"],
     )
     assert not torch.isnan(predictions).any()
-    assert batch_y.shape == (
+    assert batch_y[0].shape == (
         actual_batch_size,
         MAX_PREDICTION_LENGTH_TEST,
     )

--- a/tests/test_models/test_tft_v2.py
+++ b/tests/test_models/test_tft_v2.py
@@ -18,6 +18,12 @@ NUM_LAYERS_TEST = 1
 DROPOUT_TEST = 0.1
 
 
+def _move_to_device(val, device):
+    if isinstance(val, list):
+        return [v.to(device) for v in val]
+    return val.to(device)
+
+
 def get_default_test_metadata(
     enc_cont=2,
     enc_cat=1,
@@ -224,7 +230,7 @@ def test_forward_pass_configs(
     model = TFT(**model_params, metadata=metadata)
     model.eval()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model.to(device)
+    _move_to_device(model, device)
     x = create_tft_input_batch_for_test(
         metadata, batch_size=BATCH_SIZE_TEST, device=device
     )
@@ -360,14 +366,14 @@ def test_model_with_datamodule_integration(
     tft_init_args["output_size"] = model_metadata_from_dm["target"]
     model = TFT(**tft_init_args, metadata=model_metadata_from_dm)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model.to(device)
+    _move_to_device(model, device)
     model.eval()
 
     train_loader = dm.train_dataloader()
     batch_x, batch_y = next(iter(train_loader))
 
     actual_batch_size = batch_x["encoder_cont"].shape[0]
-    batch_x = {k: v.to(device) for k, v in batch_x.items()}
+    batch_x = {k: _move_to_device(v, device) for k, v in batch_x.items()}
 
     assert batch_x["encoder_cont"].shape[2] == model_metadata_from_dm["encoder_cont"]
     assert batch_x["encoder_cat"].shape[2] == model_metadata_from_dm["encoder_cat"]
@@ -390,7 +396,7 @@ def test_model_with_datamodule_integration(
         model_metadata_from_dm["target"],
     )
     assert not torch.isnan(predictions).any()
-    assert batch_y[0].shape == (
+    assert batch_y[0][0].shape == (
         actual_batch_size,
         MAX_PREDICTION_LENGTH_TEST,
     )


### PR DESCRIPTION
This PR adds support for `MultiLoss` to `ptf` v2

Fixes #2308
### Changes
- [x] Add `weights` to the `collate_fn` and `__getitem__` (of private dataset class of datamodule) return for `MultiLoss`. The return would be `(x, (y, weight))` in place of `(x,y)`.
    Done to:
    - [x] `EncoderDecoderTimeSeriesDataModule`
    - [x] `TslibDataModule`
- [x]  Add support to `BaseModel`. 
- [ ] Add tests and update the test framework - maybe should happen in a new PR instead - along with fixes if needed?