### PR TITLE
[ENH] add _tags.py to registry

### DIFF
--- a/extension_templates/v2/README.md
+++ b/extension_templates/v2/README.md
@@ -40,17 +40,13 @@ Inherits from `Base_pkg`. Implement the following:
 **Tags (`_tags`):**
 Dictionary defining framework integration rules. Tags are inherited from parent class if they are not set.
 
-- `info:name` (human-readable model name matching the class)
-- `info:pred_type` (prediction types: e.g. `["point"]`, `["quantile"]`, `["distr"]`)
-- `info:y_type` (target type: e.g. `["numeric"]`, `["category"]`)
-- `info:compute` (integer representing compute intensity, 1 to 5)
-- `authors` (GitHub username list)
-- `python_dependencies` (list of external packages if needed)
-- `capability:exogenous` (bool: whether model supports exogenous variables)
-- `capability:multivariate` (bool: whether model supports multivariate targets)
-- `capability:pred_int` (bool: whether model supports prediction intervals)
-- `capability:flexible_history_length` (bool: whether model works with variable-length history)
-- `capability:cold_start` (bool: whether model makes predictions with little/no history)
+Common tags for forecaster models include `info:name`, `info:pred_type`, `info:y_type`,
+`info:compute`, `authors`, `python_dependencies`, and the `capability:*` flags
+(`exogenous`, `multivariate`, `pred_int`, `flexible_history_length`, `cold_start`).
+
+For the full list of tags, their expected value types, and descriptions, see the tag
+registry at `pytorch_forecasting/_registry/_tags.py`, or call
+`pytorch_forecasting._registry.all_tags()`.
 
 **Mandatory Methods:**
 

--- a/pytorch_forecasting/_registry/__init__.py
+++ b/pytorch_forecasting/_registry/__init__.py
@@ -1,5 +1,5 @@
 """PyTorch Forecasting registry."""
 
-from pytorch_forecasting._registry._lookup import all_objects
+from pytorch_forecasting._registry._lookup import all_objects, all_tags
 
-__all__ = ["all_objects"]
+__all__ = ["all_objects", "all_tags"]

--- a/pytorch_forecasting/_registry/_lookup.py
+++ b/pytorch_forecasting/_registry/_lookup.py
@@ -4,6 +4,9 @@ This module exports the following methods for registry lookup:
 
 all_objects(object_types, filter_tags)
     lookup and filtering of objects
+
+all_tags(object_types)
+    lookup and filtering of tags
 """
 
 # based on the sktime module of same name
@@ -14,8 +17,10 @@ __author__ = ["fkiraly"]
 from inspect import isclass
 from pathlib import Path
 
+import pandas as pd
 from skbase.lookup import all_objects as _all_objects
 
+from pytorch_forecasting._registry._tags import OBJECT_TAG_REGISTER
 from pytorch_forecasting.base._base_object import _BaseObject
 
 
@@ -207,6 +212,59 @@ def all_objects(
     )
 
     return result
+
+
+def all_tags(object_types=None, as_dataframe=False):
+    """Get a list of all tags from pytorch_forecasting.
+
+    Retrieves tags directly from ``_tags``, offers filtering functionality.
+
+    Parameters
+    ----------
+    object_types : string, list of string, optional (default=None)
+        Which kind of objects the tags should apply to.
+        If None, no filter is applied and all tags are returned.
+    as_dataframe : bool, optional (default=False)
+        if False, return is as described below;
+        if True, return is converted into a pandas.DataFrame for pretty display
+
+    Returns
+    -------
+    tags : list of tuples (a, b, c, d), in alphabetical order by a
+        a : string - name of the tag as used in the ``_tags`` dictionary
+        b : string - name of the object_type this tag applies to,
+                     e.g., "forecaster_pytorch_v1", "metric"
+        c : string - expected type of the tag value
+            should be one of:
+                "bool" - valid values are True/False
+                "int" - valid values are all integers
+                "str" - valid values are all strings
+                "list" - valid values are all lists of arbitrary elements
+                ("str", list_of_string) - any string in list_of_string is valid
+                ("list", list_of_string) - any individual string and sub-list is valid
+        d : string - plain English description of the tag
+    """
+
+    def _is_tag_for_type(tag, object_types):
+        tag_types = tag[1]
+        if isinstance(tag_types, str):
+            tag_types = [tag_types]
+        return len(set(tag_types).intersection(set(object_types))) > 0
+
+    all_tags_ = OBJECT_TAG_REGISTER
+
+    if object_types:
+        if isinstance(object_types, str):
+            object_types = [object_types]
+        all_tags_ = [tag for tag in all_tags_ if _is_tag_for_type(tag, object_types)]
+
+    all_tags_ = sorted(all_tags_, key=lambda tag: tag[0])
+
+    if as_dataframe:
+        columns = ["name", "object_type", "type", "description"]
+        all_tags_ = pd.DataFrame(all_tags_, columns=columns)
+
+    return all_tags_
 
 
 def _check_list_of_str_or_error(arg_to_check, arg_name):

--- a/pytorch_forecasting/_registry/_tags.py
+++ b/pytorch_forecasting/_registry/_tags.py
@@ -1,0 +1,396 @@
+"""Register of estimator and object tags.
+
+Note for extenders: new tags should be entered in OBJECT_TAG_REGISTER.
+No other place is necessary to add new tags.
+
+This module exports the following:
+
+---
+OBJECT_TAG_REGISTER - list of tuples
+
+each tuple corresponds to a tag, elements as follows:
+    0 : string - name of the tag as used in the _tags dictionary
+    1 : string - name of the object_type this tag applies to,
+                 e.g., "forecaster_pytorch_v1", "forecaster_pytorch_v2", "metric",
+                 or "object" if the tag applies to all objects
+    2 : string - expected type of the tag value
+        should be one of:
+            "bool" - valid values are True/False
+            "int" - valid values are all integers
+            "str" - valid values are all strings
+            "list" - valid values are all lists of arbitrary elements
+            ("str", list_of_string) - any string in list_of_string is valid
+            ("list", list_of_string) - any individual string and sub-list is valid
+            ("list", "str") - any individual string or list of strings is valid
+        validity can be checked by check_tag_is_valid (see below)
+    3 : string - plain English description of the tag
+
+---
+
+OBJECT_TAG_TABLE - pd.DataFrame
+    OBJECT_TAG_REGISTER in table form, as pd.DataFrame
+        rows of OBJECT_TAG_TABLE correspond to elements in OBJECT_TAG_REGISTER
+
+OBJECT_TAG_LIST - list of string
+    elements are 0-th entries of OBJECT_TAG_REGISTER, in same order
+
+---
+
+check_tag_is_valid(tag_name, tag_value) - checks whether tag_value is valid for tag_name
+"""
+
+import inspect
+import sys
+
+import pandas as pd
+
+from pytorch_forecasting.base._base_object import _BaseObject
+
+# ---------------------------------------------------------
+# Tag Class Definitions
+# ---------------------------------------------------------
+
+
+class _BaseTag(_BaseObject):
+    """Base class for all tags in pytorch-forecasting.
+
+    This follows the class-based tag registry pattern used in sktime and skpro,
+    for better extensibility and single-source-of-truth tag documentation.
+    """
+
+    _tags = {
+        "object_type": "tag",
+        "tag_name": "",
+        "parent_type": "object",
+        "tag_type": "str",
+        "short_descr": "",
+    }
+
+
+# --------------------------
+# All objects
+# --------------------------
+
+_FORECASTER_TYPES = ["forecaster_pytorch_v1", "forecaster_pytorch_v2"]
+
+
+class object_type(_BaseTag):
+    """Type of object, e.g., 'forecaster_pytorch_v1', 'metric'."""
+
+    _tags = {
+        "tag_name": "object_type",
+        "parent_type": "object",
+        "tag_type": (
+            "str",
+            ["forecaster_pytorch_v1", "forecaster_pytorch_v2", "metric"],
+        ),
+        "short_descr": "type of object, e.g., forecaster_pytorch_v1, metric",
+    }
+
+
+class authors(_BaseTag):
+    """List of GitHub handles of the object's authors."""
+
+    _tags = {
+        "tag_name": "authors",
+        "parent_type": "object",
+        "tag_type": "list",
+        "short_descr": "list of GitHub handles of the object's authors",
+    }
+
+
+class python_dependencies(_BaseTag):
+    """List of external Python packages required by the object."""
+
+    _tags = {
+        "tag_name": "python_dependencies",
+        "parent_type": "object",
+        "tag_type": "list",
+        "short_descr": "list of external python packages required by the object",
+    }
+
+
+class tests_skip_by_name(_BaseTag):
+    """Names of tests to skip in CI for this object."""
+
+    _tags = {
+        "tag_name": "tests:skip_by_name",
+        "parent_type": "object",
+        "tag_type": "list",
+        "short_descr": "names of tests to skip in CI for this object",
+    }
+
+
+# --------------------------
+# Forecasters (v1 and v2)
+# --------------------------
+
+
+class info_name(_BaseTag):
+    """Human-readable model name."""
+
+    _tags = {
+        "tag_name": "info:name",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": "str",
+        "short_descr": "human-readable model name, matching the class name",
+    }
+
+
+class info_compute(_BaseTag):
+    """Compute intensity of the model."""
+
+    _tags = {
+        "tag_name": "info:compute",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": "int",
+        "short_descr": "compute intensity of the model, from 1 (light) to 5 (heavy)",
+    }
+
+
+class info_pred_type(_BaseTag):
+    """Prediction types the model produces."""
+
+    _tags = {
+        "tag_name": "info:pred_type",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": ("list", ["point", "quantile", "distr"]),
+        "short_descr": (
+            "prediction types the model produces, e.g. point, quantile, distr"
+        ),
+    }
+
+
+class info_y_type(_BaseTag):
+    """Target data type(s) the model supports."""
+
+    _tags = {
+        "tag_name": "info:y_type",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": "list",
+        "short_descr": "target data type(s) the model supports, e.g. numeric, category",
+    }
+
+
+class capability_cold_start(_BaseTag):
+    """Whether the model can forecast with little or no history."""
+
+    _tags = {
+        "tag_name": "capability:cold_start",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": "bool",
+        "short_descr": "whether the model can forecast with little or no history",
+    }
+
+
+class capability_exogenous(_BaseTag):
+    """Whether the model supports exogenous variables."""
+
+    _tags = {
+        "tag_name": "capability:exogenous",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": "bool",
+        "short_descr": "whether the model supports exogenous variables",
+    }
+
+
+class capability_flexible_history_length(_BaseTag):
+    """Whether the model works with variable-length input history."""
+
+    _tags = {
+        "tag_name": "capability:flexible_history_length",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": "bool",
+        "short_descr": "whether the model works with variable-length input history",
+    }
+
+
+class capability_multivariate(_BaseTag):
+    """Whether the model supports multivariate targets."""
+
+    _tags = {
+        "tag_name": "capability:multivariate",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": "bool",
+        "short_descr": "whether the model supports multivariate targets",
+    }
+
+
+class capability_pred_int(_BaseTag):
+    """Whether the model produces prediction intervals."""
+
+    _tags = {
+        "tag_name": "capability:pred_int",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": "bool",
+        "short_descr": "whether the model produces prediction intervals",
+    }
+
+
+class capability_quantile_generation(_BaseTag):
+    """Whether the model supports quantile output generation."""
+
+    _tags = {
+        "tag_name": "capability:quantile_generation",
+        "parent_type": _FORECASTER_TYPES,
+        "tag_type": "bool",
+        "short_descr": "whether the model supports quantile output generation",
+    }
+
+
+# --------------------------
+# Metrics
+# --------------------------
+
+
+class info_metric_name(_BaseTag):
+    """Human-readable metric name."""
+
+    _tags = {
+        "tag_name": "info:metric_name",
+        "parent_type": "metric",
+        "tag_type": "str",
+        "short_descr": "human-readable metric name",
+    }
+
+
+class metric_type(_BaseTag):
+    """Type of metric, e.g. point, point_classification, distribution."""
+
+    _tags = {
+        "tag_name": "metric_type",
+        "parent_type": "metric",
+        "tag_type": "str",
+        "short_descr": (
+            "type of metric, e.g. point, point_classification, distribution, quantile"
+        ),
+    }
+
+
+class distribution_type(_BaseTag):
+    """Distribution family used by a distributional loss."""
+
+    _tags = {
+        "tag_name": "distribution_type",
+        "parent_type": "metric",
+        "tag_type": "str",
+        "short_descr": "distribution family used by a distributional loss, e.g. normal",
+    }
+
+
+class requires_data_type(_BaseTag):
+    """Expected input data format for the metric."""
+
+    _tags = {
+        "tag_name": "requires:data_type",
+        "parent_type": "metric",
+        "tag_type": "str",
+        "short_descr": (
+            "expected input data format for the metric, "
+            "e.g. point_forecast, classification_forecast"
+        ),
+    }
+
+
+class no_rescaling(_BaseTag):
+    """Whether the metric is invariant to rescaling."""
+
+    _tags = {
+        "tag_name": "no_rescaling",
+        "parent_type": "metric",
+        "tag_type": "bool",
+        "short_descr": "whether the metric is invariant to rescaling of the target",
+    }
+
+
+class shape_adds_quantile_dimension(_BaseTag):
+    """Whether the metric output adds an extra quantile axis."""
+
+    _tags = {
+        "tag_name": "shape:adds_quantile_dimension",
+        "parent_type": "metric",
+        "tag_type": "bool",
+        "short_descr": "whether the metric output adds an extra quantile axis",
+    }
+
+
+# ---------------------------------------------------------
+# Registry Generation Logic
+# ---------------------------------------------------------
+
+OBJECT_TAG_REGISTER = []
+tag_classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
+
+for _, cl in tag_classes:
+    if cl.__name__ == "_BaseTag" or not issubclass(cl, _BaseTag):
+        continue
+
+    cl_tags = cl.get_class_tags()
+    tag_name = cl_tags.get("tag_name", "unknown_tag")
+    parent_type = cl_tags.get("parent_type", "object")
+    tag_type = cl_tags.get("tag_type", "str")
+    short_descr = cl_tags.get("short_descr", "")
+
+    if isinstance(parent_type, list):
+        for p_type in parent_type:
+            OBJECT_TAG_REGISTER.append((tag_name, p_type, tag_type, short_descr))
+    else:
+        OBJECT_TAG_REGISTER.append((tag_name, parent_type, tag_type, short_descr))
+
+OBJECT_TAG_TABLE = pd.DataFrame(OBJECT_TAG_REGISTER)
+OBJECT_TAG_LIST = OBJECT_TAG_TABLE[0].unique().tolist()
+
+
+def check_tag_is_valid(tag_name, tag_value):
+    """Check validity of a tag value.
+
+    Parameters
+    ----------
+    tag_name : string, name of the tag
+    tag_value : object, value of the tag
+
+    Raises
+    ------
+    KeyError - if tag_name is not a valid tag in OBJECT_TAG_LIST
+    ValueError - if the tag_value is not valid for the tag with name tag_name
+    """
+    if tag_name not in OBJECT_TAG_LIST:
+        raise KeyError(f"{tag_name} is not a valid tag")
+
+    tag_row = OBJECT_TAG_TABLE[OBJECT_TAG_TABLE[0] == tag_name]
+    tag_type = tag_row.iloc[0, 2]
+
+    # Validation logic for strings/types
+    if isinstance(tag_type, str):
+        if tag_type == "bool" and not isinstance(tag_value, bool):
+            raise ValueError(f"{tag_name} must be bool, found {type(tag_value)}")
+        if tag_type == "int" and not isinstance(tag_value, int):
+            raise ValueError(f"{tag_name} must be int, found {type(tag_value)}")
+        if tag_type == "str" and not isinstance(tag_value, str):
+            raise ValueError(f"{tag_name} must be str, found {type(tag_value)}")
+        if tag_type == "list" and not isinstance(tag_value, list):
+            raise ValueError(f"{tag_name} must be list, found {type(tag_value)}")
+
+    # Validation logic for complex types (tuples)
+    elif isinstance(tag_type, tuple):
+        if tag_type[0] == "str":
+            if tag_value not in tag_type[1]:
+                raise ValueError(
+                    f"{tag_name} must be one of {tag_type[1]}, found {tag_value}"
+                )
+
+        elif tag_type[0] == "list" and tag_type[1] == "str":
+            if not isinstance(tag_value, (str, list)):
+                raise ValueError(
+                    f"{tag_name} must be str or list of str, found {type(tag_value)}"
+                )
+            if isinstance(tag_value, list) and not all(
+                isinstance(x, str) for x in tag_value
+            ):
+                raise ValueError(f"{tag_name} must be a list of strings.")
+
+        elif tag_type[0] == "list" and isinstance(tag_type[1], list):
+            if not isinstance(tag_value, list) or not set(tag_value).issubset(
+                tag_type[1]
+            ):
+                raise ValueError(f"{tag_name} must be a subset of {tag_type[1]}")

--- a/pytorch_forecasting/_registry/_tags.py
+++ b/pytorch_forecasting/_registry/_tags.py
@@ -46,10 +46,6 @@ import pandas as pd
 
 from pytorch_forecasting.base._base_object import _BaseObject
 
-# ---------------------------------------------------------
-# Tag Class Definitions
-# ---------------------------------------------------------
-
 
 class _BaseTag(_BaseObject):
     """Base class for all tags in pytorch-forecasting.
@@ -66,10 +62,6 @@ class _BaseTag(_BaseObject):
         "short_descr": "",
     }
 
-
-# --------------------------
-# All objects
-# --------------------------
 
 _FORECASTER_TYPES = ["forecaster_pytorch_v1", "forecaster_pytorch_v2"]
 
@@ -119,11 +111,6 @@ class tests_skip_by_name(_BaseTag):
         "tag_type": "list",
         "short_descr": "names of tests to skip in CI for this object",
     }
-
-
-# --------------------------
-# Forecasters (v1 and v2)
-# --------------------------
 
 
 class info_name(_BaseTag):
@@ -238,11 +225,6 @@ class capability_quantile_generation(_BaseTag):
     }
 
 
-# --------------------------
-# Metrics
-# --------------------------
-
-
 class info_metric_name(_BaseTag):
     """Human-readable metric name."""
 
@@ -314,10 +296,6 @@ class shape_adds_quantile_dimension(_BaseTag):
     }
 
 
-# ---------------------------------------------------------
-# Registry Generation Logic
-# ---------------------------------------------------------
-
 OBJECT_TAG_REGISTER = []
 tag_classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
 
@@ -360,7 +338,6 @@ def check_tag_is_valid(tag_name, tag_value):
     tag_row = OBJECT_TAG_TABLE[OBJECT_TAG_TABLE[0] == tag_name]
     tag_type = tag_row.iloc[0, 2]
 
-    # Validation logic for strings/types
     if isinstance(tag_type, str):
         if tag_type == "bool" and not isinstance(tag_value, bool):
             raise ValueError(f"{tag_name} must be bool, found {type(tag_value)}")
@@ -371,7 +348,6 @@ def check_tag_is_valid(tag_name, tag_value):
         if tag_type == "list" and not isinstance(tag_value, list):
             raise ValueError(f"{tag_name} must be list, found {type(tag_value)}")
 
-    # Validation logic for complex types (tuples)
     elif isinstance(tag_type, tuple):
         if tag_type[0] == "str":
             if tag_value not in tag_type[1]:

--- a/pytorch_forecasting/tests/test_registry_tags.py
+++ b/pytorch_forecasting/tests/test_registry_tags.py
@@ -36,13 +36,10 @@ def test_tag_register_type():
 
 def test_check_tag_is_valid():
     """Test that check_tag_is_valid accepts valid and rejects invalid values."""
-    # simple types: bool, str, int, list
     check_tag_is_valid("capability:multivariate", True)
     check_tag_is_valid("info:name", "DeepAR")
     check_tag_is_valid("info:compute", 3)
     check_tag_is_valid("authors", ["some-author"])
-
-    # tuple types: ("str", choices) and ("list", choices)
     check_tag_is_valid("object_type", "metric")
     check_tag_is_valid("info:pred_type", ["point"])
 

--- a/pytorch_forecasting/tests/test_registry_tags.py
+++ b/pytorch_forecasting/tests/test_registry_tags.py
@@ -1,0 +1,109 @@
+"""Tests for the tag register and tag lookup functionality."""
+
+import ast
+from pathlib import Path
+
+from pytorch_forecasting._registry import all_tags
+from pytorch_forecasting._registry._tags import (
+    OBJECT_TAG_LIST,
+    OBJECT_TAG_REGISTER,
+    check_tag_is_valid,
+)
+
+
+def test_tag_register_type():
+    """Test the specification of the tag register. See _tags for specs."""
+    assert isinstance(OBJECT_TAG_REGISTER, list)
+    assert all(isinstance(tag, tuple) for tag in OBJECT_TAG_REGISTER)
+
+    for tag in OBJECT_TAG_REGISTER:
+        assert len(tag) == 4
+        assert isinstance(tag[0], str)
+        assert isinstance(tag[1], (str, list))
+        if isinstance(tag[1], list):
+            assert all(isinstance(x, str) for x in tag[1])
+        assert isinstance(tag[2], (str, tuple))
+        if isinstance(tag[2], tuple):
+            assert len(tag[2]) == 2
+            assert isinstance(tag[2][0], str)
+            assert isinstance(tag[2][1], (list, str))
+            if isinstance(tag[2][1], list):
+                assert all(isinstance(x, str) for x in tag[2][1])
+        assert isinstance(tag[3], str)
+
+
+def test_check_tag_is_valid():
+    """Test that check_tag_is_valid accepts valid and rejects invalid values."""
+    check_tag_is_valid("capability:multivariate", True)
+    check_tag_is_valid("info:name", "DeepAR")
+
+    try:
+        check_tag_is_valid("capability:multivariate", "not_a_bool")
+        raise AssertionError("expected ValueError for wrong tag type")
+    except ValueError:
+        pass
+
+    try:
+        check_tag_is_valid("not_a_real_tag", 42)
+        raise AssertionError("expected KeyError for unknown tag name")
+    except KeyError:
+        pass
+
+
+def test_all_tags_filters_by_object_type():
+    """Test that all_tags filters correctly by object_type."""
+    metric_tags = all_tags(object_types="metric")
+    metric_tag_names = {tag[0] for tag in metric_tags}
+    assert "metric_type" in metric_tag_names
+    assert "capability:multivariate" not in metric_tag_names
+
+    df = all_tags(as_dataframe=True)
+    assert list(df.columns) == ["name", "object_type", "type", "description"]
+
+
+def _find_tag_keys_in_use():
+    """Collect every tag key set in a ``_tags = {...}`` literal in the package."""
+    package_root = Path(__file__).parent.parent
+    # the tag definition module itself uses "_tags" for its own tag-class schema
+    # (tag_name, parent_type, tag_type, short_descr), not for tagging real objects
+    registry_tags_file = package_root / "_registry" / "_tags.py"
+    tag_keys = set()
+
+    for path in package_root.rglob("*.py"):
+        if path == registry_tags_file:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        for node in ast.walk(tree):
+            is_tags_assign = (
+                isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == "_tags"
+                and isinstance(node.value, ast.Dict)
+            )
+            if not is_tags_assign:
+                continue
+            for key in node.value.keys:
+                if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                    tag_keys.add(key.value)
+
+    return tag_keys
+
+
+def test_all_used_tags_are_registered():
+    """Test that every tag used in the package is documented in OBJECT_TAG_LIST.
+
+    Catches tags being added to a ``_pkg.py`` class without a corresponding
+    entry in ``pytorch_forecasting/_registry/_tags.py``.
+    """
+    used_tags = _find_tag_keys_in_use()
+    undocumented = used_tags - set(OBJECT_TAG_LIST)
+
+    assert not undocumented, (
+        f"The following tags are used in the codebase but not registered in "
+        f"pytorch_forecasting/_registry/_tags.py: {sorted(undocumented)}"
+    )

--- a/pytorch_forecasting/tests/test_registry_tags.py
+++ b/pytorch_forecasting/tests/test_registry_tags.py
@@ -3,6 +3,8 @@
 import ast
 from pathlib import Path
 
+import pytest
+
 from pytorch_forecasting._registry import all_tags
 from pytorch_forecasting._registry._tags import (
     OBJECT_TAG_LIST,
@@ -34,20 +36,33 @@ def test_tag_register_type():
 
 def test_check_tag_is_valid():
     """Test that check_tag_is_valid accepts valid and rejects invalid values."""
+    # simple types: bool, str, int, list
     check_tag_is_valid("capability:multivariate", True)
     check_tag_is_valid("info:name", "DeepAR")
+    check_tag_is_valid("info:compute", 3)
+    check_tag_is_valid("authors", ["some-author"])
 
-    try:
+    # tuple types: ("str", choices) and ("list", choices)
+    check_tag_is_valid("object_type", "metric")
+    check_tag_is_valid("info:pred_type", ["point"])
+
+    with pytest.raises(ValueError):
         check_tag_is_valid("capability:multivariate", "not_a_bool")
-        raise AssertionError("expected ValueError for wrong tag type")
-    except ValueError:
-        pass
 
-    try:
+    with pytest.raises(ValueError):
+        check_tag_is_valid("info:compute", "not_an_int")
+
+    with pytest.raises(ValueError):
+        check_tag_is_valid("authors", "not_a_list")
+
+    with pytest.raises(ValueError):
+        check_tag_is_valid("object_type", "not_a_valid_object_type")
+
+    with pytest.raises(ValueError):
+        check_tag_is_valid("info:pred_type", ["not_a_valid_pred_type"])
+
+    with pytest.raises(KeyError):
         check_tag_is_valid("not_a_real_tag", 42)
-        raise AssertionError("expected KeyError for unknown tag name")
-    except KeyError:
-        pass
 
 
 def test_all_tags_filters_by_object_type():


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2333

#### What does this implement/fix? Explain your changes.

adds a class-based tag registry to pytorch-forecasting, following the same
pattern already used in sktime (`sktime/registry/_tags.py`) and skpro
(`skpro/registry/_tags.py`).

- new `pytorch_forecasting/_registry/_tags.py`: `_BaseTag` base class plus one
  subclass per tag currently in use across the codebase (19 tags total, covering
  `object_type`, `capability:*`, `info:*`, `requires:data_type`, and metric-specific
  tags), a discovery loop building `OBJECT_TAG_REGISTER`/`_TABLE`/`_LIST`, and
  `check_tag_is_valid`.
- `all_tags()` added to `_registry/_lookup.py` , this closes a gap where
  `all_objects()`'s own docstring already referenced a `registry.all_tags` utility
  that didn't exist yet.
- exported `all_tags` from `_registry/__init__.py`.
- trimmed the duplicated inline tag descriptions in
  `extension_templates/v2/README.md` down to a short summary plus a pointer to
  the new registry as the single source of truth.

#### What should a reviewer concentrate their feedback on?

- whether the 19 tags and their `short_descr` text accurately reflect intended
  usage (descriptions were written from reading existing `_pkg.py` files, not
  guessed).
- whether `parent_type` values (plain `object_type` strings like
  `forecaster_pytorch_v1`/`forecaster_pytorch_v2`/`metric`) are the right
  granularity, given pytorch-forecasting doesn't have a formal scitype-class
  registry like sktime/skpro do.

#### Did you add any tests for the change?

yes, `pytorch_forecasting/tests/test_registry_tags.py` (4 tests, all passing):
registry shape, `check_tag_is_valid` behavior, `all_tags` filtering, and an
AST-based drift check asserting every tag actually used anywhere in the
package is registered in the new module.

#### Any other comments?

 verified locally: new tests pass, plus existing `test_class_register.py` and
`test_base_pkg.py` still pass. Did not run `pre-commit` locally (not installed
in this environment), worth a check in CI.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks.