### PR TITLE
Fix TslibDataModule generating synthetic time indices instead of real ones

### DIFF
--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -24,6 +24,18 @@ from pytorch_forecasting.utils._coerce import _coerce_to_dict
 NORMALIZER = TorchNormalizer | EncoderNormalizer | NaNLabelEncoder
 
 
+def _time_values_to_tensor(values: np.ndarray) -> torch.Tensor:
+    """Convert a numpy array of time values to a torch tensor.
+
+    ``torch.as_tensor`` rejects ``datetime64`` arrays outright, so datetime-like
+    time axes (as opposed to plain integer/float time steps) are viewed as their
+    underlying int64 ticks first.
+    """
+    if np.issubdtype(values.dtype, np.datetime64):
+        values = values.astype("int64")
+    return torch.as_tensor(values)
+
+
 class _TslibDataset(Dataset):
     """
     Dataset class for `tslib` time series dataset.
@@ -192,8 +204,12 @@ class _TslibDataset(Dataset):
         history_target = processed_data["target"][history_indices]
         future_target = processed_data["target"][future_indices]
 
-        # history_time_idx = processed_data["timestep"][history_indices]
-        # future_time_idx = processed_data["timestep"][future_indices]
+        history_time_idx = _time_values_to_tensor(
+            processed_data["timestep"][history_indices]
+        )
+        future_time_idx = _time_values_to_tensor(
+            processed_data["timestep"][future_indices]
+        )
 
         x = {
             "history_cont": history_cont,
@@ -205,10 +221,8 @@ class _TslibDataset(Dataset):
             "history_mask": history_mask,
             "future_mask": future_mask,
             "groups": processed_data["group"],
-            "history_time_idx": torch.arange(context_length),
-            "future_time_idx": torch.arange(
-                context_length, context_length + prediction_length
-            ),
+            "history_time_idx": history_time_idx,
+            "future_time_idx": future_time_idx,
             "history_target": history_target,
             "future_target": future_target,
             "future_target_len": torch.tensor(prediction_length),

--- a/pytorch_forecasting/data/tests/test_tslib_data_module.py
+++ b/pytorch_forecasting/data/tests/test_tslib_data_module.py
@@ -269,6 +269,82 @@ def test_tslib_dataset(tslib_data_module):
     assert sample_y.dtype == torch.float32
 
 
+def test_time_idx_reflects_real_timestamps():
+    """Regression test: history/future_time_idx must propagate the dataset's
+    real, per-series time values rather than synthetic positional indices
+    (torch.arange), which breaks for non-zero-start or irregular time axes.
+    See: https://github.com/sktime/pytorch-forecasting/issues/2263"""
+    df = pd.DataFrame(
+        {
+            "time_idx": [10, 20, 35, 50, 80, 120],
+            "group_id": ["A"] * 6,
+            "value": [1.0, 1.2, 1.4, 1.3, 1.5, 1.7],
+        }
+    )
+
+    ts = TimeSeries(
+        data=df,
+        time="time_idx",
+        target="value",
+        group=["group_id"],
+        num=["value"],
+        known=["time_idx"],
+    )
+
+    dm = TslibDataModule(
+        time_series_dataset=ts,
+        context_length=3,
+        prediction_length=2,
+        batch_size=1,
+        train_val_test_split=(1.0, 0.0, 0.0),
+    )
+    dm.setup(stage="fit")
+    train_dataset = dm.train_dataset
+
+    all_time_idx = df["time_idx"].tolist()
+    for i in range(len(train_dataset)):
+        x, _ = train_dataset[i]
+        history = x["history_time_idx"].tolist()
+        future = x["future_time_idx"].tolist()
+
+        # values must come from the dataset's own time axis, not torch.arange(...)
+        assert all(v in all_time_idx for v in history + future)
+        # history and future must be contiguous, in-order windows of the real axis
+        combined = history + future
+        assert combined == sorted(combined)
+        start = all_time_idx.index(history[0])
+        assert all_time_idx[start : start + len(combined)] == combined
+
+
+def test_time_idx_supports_datetime_time_column():
+    """history/future_time_idx conversion must also handle a datetime64 time
+    axis (torch.as_tensor rejects datetime64 directly)."""
+    df = pd.DataFrame(
+        {
+            "time": pd.date_range("2020-01-01", periods=6, freq="D"),
+            "group_id": ["A"] * 6,
+            "value": [1.0, 1.2, 1.4, 1.3, 1.5, 1.7],
+        }
+    )
+
+    ts = TimeSeries(
+        data=df, time="time", target="value", group=["group_id"], num=["value"]
+    )
+
+    dm = TslibDataModule(
+        time_series_dataset=ts,
+        context_length=3,
+        prediction_length=2,
+        batch_size=1,
+        train_val_test_split=(1.0, 0.0, 0.0),
+    )
+    dm.setup(stage="fit")
+
+    x, _ = dm.train_dataset[0]
+    assert x["history_time_idx"].dtype == torch.int64
+    assert x["future_time_idx"].dtype == torch.int64
+
+
 def test_collate_fn(tslib_data_module):
     """Test the collate function in the TslibDataModule to ensure it correctly
     collates the data into batches and properly handles stacking of batches."""


### PR DESCRIPTION
## Summary

Fixes #2263.

`_TslibDataset.__getitem__` built `history_time_idx`/`future_time_idx` from `torch.arange(context_length)` and `torch.arange(context_length, context_length + prediction_length)` — synthetic, always-zero-start positional indices — instead of the real per-series timestep values already computed in `processed_data["timestep"]`. The line reading from it was present in the source but commented out:

```python
# history_time_idx = processed_data["timestep"][history_indices]
# future_time_idx = processed_data["timestep"][future_indices]
...
"history_time_idx": torch.arange(context_length),
"future_time_idx": torch.arange(context_length, context_length + prediction_length),
```

For any window that doesn't start at series position 0, or for irregular/gapped time axes, this silently fed models the wrong temporal context. Using the issue's repro (`time_idx = [10, 20, 35, 50, 80, 120]`, `context_length=3`, `prediction_length=2`):

```python
print(batch["history_time_idx"][0])  # tensor([0, 1, 2])  -- should be [10, 20, 35]
print(batch["future_time_idx"][0])   # tensor([3, 4])     -- should be [50, 80]
```

## Fix

Restored `history_time_idx`/`future_time_idx` to read from `processed_data["timestep"]`. One wrinkle: `TimeSeries.__getitem__` returns `t` as a plain `numpy.ndarray` (not a tensor), and a time column can legitimately be `datetime64` (see `test_multivariate_target` in the existing test file, which uses `pd.date_range`) — `torch.as_tensor` rejects `datetime64` arrays outright. Added a small `_time_values_to_tensor` helper that views `datetime64` values as their underlying int64 ticks before conversion; plain int/float time columns pass through unchanged.

## Test plan

- [x] Added `test_time_idx_reflects_real_timestamps`, using the exact irregular, non-zero-start reproduction from the issue — asserts `history_time_idx`/`future_time_idx` are a real, contiguous, in-order slice of the dataset's own time axis for every window. Confirmed this fails with the original synthetic-`arange` output on the pre-fix code and passes after the fix.
- [x] Added `test_time_idx_supports_datetime_time_column`, covering a `datetime64` time column end-to-end (this would `TypeError` on a naive `torch.as_tensor(...)` fix without the datetime handling).
- [x] `pytest pytorch_forecasting/data/tests/test_tslib_data_module.py -v` — 15 passed, 1 failed. The failure (`test_multivariate_target`, `AttributeError: 'list' object has no attribute 'shape'`) is the same pre-existing, unrelated failure flagged in the issue itself — confirmed by reproducing the identical failure against the unmodified file on `main`.
- [x] `ruff check` / `ruff format --check` on both changed files — clean (left one unrelated pre-existing formatting drift elsewhere in the source file untouched, to keep the diff focused).