### PR TITLE
[ENH] Add multiloss support for v2 by adding one more dimension to `x` and `y`

### DIFF
--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -377,21 +377,24 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
     def _coerce_sample(
         self, sample: dict
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Convert raw sample arrays to float tensors and compute time mask."""
         target = sample["y"]
         features = sample["x"]
         times = sample["t"]
         cutoff_time = sample["cutoff_time"]
+        weights = sample.get("weights", None)
 
         target = target.float()
         features = features.float()
 
         if target.ndim == 1:
             target = target.unsqueeze(-1)
+        if weights is not None:
+            weights = weights.float()
 
         time_mask = torch.tensor(times <= cutoff_time, dtype=torch.bool)
-        return target, features, times, time_mask
+        return target, features, times, time_mask, weights
 
     def _split_features(self, features: torch.Tensor) -> dict[str, torch.Tensor]:
         """Split feature tensor into categorical and continuous subsets."""
@@ -464,7 +467,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         __getitem__.
         """
         sample = self.time_series_dataset[series_idx]
-        target, features, times, time_mask = self._coerce_sample(sample)
+        target, features, times, time_mask, weights = self._coerce_sample(sample)
         split = self._split_features(features)
         target, target_original = self._normalize_target(target, series_idx)
         continuous = self._normalize_features(split["continuous"], series_idx)
@@ -472,6 +475,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         return {
             "features": {"categorical": split["categorical"], "continuous": continuous},
             "target": target,
+            "weights": weights,
             "target_original": target_original,
             "static": sample.get("st", None),
             "group": sample.get("group", torch.tensor([0])),
@@ -662,18 +666,11 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             abs_vals = target_original_past.abs().masked_fill(~valid_mask, 0.0)
             counts = valid_mask.sum(dim=0).clamp(min=1)
             target_scale_vec = abs_vals.sum(dim=0) / counts
-            target_scale_vec = torch.where(
+            target_scale = torch.where(
                 (target_scale_vec == 0) | torch.isnan(target_scale_vec),
                 torch.ones_like(target_scale_vec),
                 target_scale_vec,
             )
-
-            if self.data_module.n_targets > 1:
-                target_scale = [
-                    target_scale_vec[i] for i in range(self.data_module.n_targets)
-                ]
-            else:
-                target_scale = target_scale_vec.squeeze(0)
 
             encoder_mask = (
                 data["time_mask"][encoder_indices]
@@ -797,11 +794,14 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
             y = data["target"][decoder_indices]
 
-            if y.shape[-1] > 1:
-                y = [y[:, i] for i in range(y.shape[-1])]
+            weight = data.get("weight", None)
+            if weight is not None:
+                weight = weight[decoder_indices]
+                if weight.shape[-1] == 1 and y.shape[-1] > 1:
+                    weight = weight.expand(-1, y.shape[-1])
             else:
-                y = y.squeeze(-1)
-            return x, y
+                weight = torch.ones_like(y)
+            return x, y, weight
 
     def _create_windows(self, indices: torch.Tensor) -> list[tuple[int, int, int, int]]:
         """Generate sliding windows for training, validation, and testing.
@@ -1087,16 +1087,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             "encoder_mask": torch.stack([x["encoder_mask"] for x, _ in batch]),
             "decoder_mask": torch.stack([x["decoder_mask"] for x, _ in batch]),
         }
-        if isinstance(batch[0][0]["target_scale"], list | tuple):
-            num_targets = len(batch[0][0]["target_scale"])
-            target_scale = [
-                torch.stack([x["target_scale"][i] for x, _ in batch])
-                for i in range(num_targets)
-            ]
-        else:
-            target_scale = torch.stack([x["target_scale"] for x, _ in batch])
-
-        x_batch["target_scale"] = target_scale
+        x_batch["target_scale"] = torch.stack([x["target_scale"] for x, _, _ in batch])
 
         if "static_categorical_features" in batch[0][0]:
             x_batch["static_categorical_features"] = torch.stack(
@@ -1106,13 +1097,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 [x["static_continuous_features"] for x, _ in batch]
             )
 
-        if isinstance(batch[0][1], list | tuple):
-            num_targets = len(batch[0][1])
-            y_batch = []
-            for i in range(num_targets):
-                target_tensors = [sample_y[i] for _, sample_y in batch]
-                stacked_target = torch.stack(target_tensors)
-                y_batch.append(stacked_target)
-        else:
-            y_batch = torch.stack([y for _, y in batch])
-        return x_batch, y_batch
+        y_batch = torch.stack([y for _, y, _ in batch])
+        weight_batch = torch.stack([w for _, _, w in batch])
+
+        return x_batch, (y_batch, weight_batch)

--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -60,7 +60,7 @@ class _TslibDataset(Dataset):
     def __len__(self) -> int:
         return len(self.windows)
 
-    def __getitem__(self, idx: int) -> dict[str, Any]:
+    def __getitem__(self, idx: int):
         """
         Get the processed dataset item at the given index.
 
@@ -224,14 +224,16 @@ class _TslibDataset(Dataset):
 
         if "target_scale" in processed_data:
             x["target_scale"] = processed_data["target_scale"]
+        weights = processed_data.get("weights", None)
+        future_weight = (
+            weights[future_indices]
+            if weights is not None
+            else torch.ones(prediction_length, dtype=torch.float32)
+        )
 
         y = processed_data["target"][future_indices]
-        if self.data_module.n_targets > 1:
-            y = [t.squeeze(-1) for t in torch.split(y, 1, dim=1)]
-        else:
-            y = y.squeeze(-1)
 
-        return x, y
+        return x, y, future_weight
 
 
 class TslibDataModule(LightningDataModule):
@@ -566,6 +568,7 @@ class TslibDataModule(LightningDataModule):
         features = series["x"]
         timestep = series["t"]
         cutoff_time = series["cutoff_time"]
+        weights = series.get("weights", None)
 
         mask_timestep = torch.tensor(timestep <= cutoff_time, dtype=torch.bool)
 
@@ -578,6 +581,9 @@ class TslibDataModule(LightningDataModule):
             features = features.detach().clone().float()
         else:
             features = torch.tensor(features, dtype=torch.float32)
+
+        if weights is not None:
+            weights = weights.float()
 
         # scaling and normalization
         target_scale = {}
@@ -600,6 +606,7 @@ class TslibDataModule(LightningDataModule):
                 "continuous": continuous_features,
             },
             "target": target,
+            "weights": weights,
             "static": series["st"],
             "group": series.get("group", torch.tensor([0])),
             "length": len(series),
@@ -862,7 +869,9 @@ class TslibDataModule(LightningDataModule):
         }
 
         if "target_scale" in batch[0][0]:
-            x_batch["target_scale"] = torch.stack([x["target_scale"] for x, _ in batch])
+            x_batch["target_scale"] = torch.stack(
+                [x["target_scale"] for x, _, _ in batch]
+            )
 
         if "history_relative_time_idx" in batch[0][0]:
             x_batch["history_relative_time_idx"] = torch.stack(
@@ -880,13 +889,7 @@ class TslibDataModule(LightningDataModule):
                 [x["static_continuous_features"] for x, _ in batch]
             )
 
-        if isinstance(batch[0][1], list | tuple):
-            num_targets = len(batch[0][1])
-            y_batch = []
-            for i in range(num_targets):
-                target_tensors = [sample_y[i] for _, sample_y in batch]
-                stacked_target = torch.stack(target_tensors)
-                y_batch.append(stacked_target)
-        else:
-            y_batch = torch.stack([y for _, y in batch])
-        return x_batch, y_batch
+        y_batch = torch.stack([y for _, y, _ in batch])
+        weight_batch = torch.stack([w for _, _, w in batch])
+
+        return x_batch, y_batch, weight_batch


### PR DESCRIPTION
This PR adds support for MultiLoss to ptf v2

Fixes https://github.com/sktime/pytorch-forecasting/issues/2308

### Changes
- [x] Add `weights` to the `collate_fn` and `__getitem__` (of private dataset class of datamodule) return for `MultiLoss`. The return would be `(x, (y, weight))` in place of `(x,y)`.
    Done to:
    - [x] `EncoderDecoderTimeSeriesDataModule`
    - [x] `TslibDataModule`
- [ ]  Add support to `BaseModel`. 
- [ ] Add tests and update the test framework - maybe should happen in a new PR instead - along with fixes if needed?