### PR TITLE
[BUG] Normalize decoder target when using EncoderNormalizer in EncoderDecoderDataModule

### DIFF
--- a/pytorch_forecasting/adapters/scaler_adapters.py
+++ b/pytorch_forecasting/adapters/scaler_adapters.py
@@ -199,3 +199,44 @@ class ScalerAdapter:
             col = sub.fit_transform(col, X) if sub.fit_per_sequence else col
             columns.append(col.unsqueeze(-1))
         return torch.cat(columns, dim=-1)
+
+    def transform_sequence(
+        self, data: ArrayLike, X: pd.DataFrame = None
+    ) -> torch.Tensor:
+        """Transform only per-sequence sub-normalizers; leave the rest untouched.
+
+        Companion to :meth:`fit_transform_sequence`. Used at ``__getitem__`` time
+        for the decoder target, which must reuse the parameters that
+        ``fit_transform_sequence`` just fitted on the *encoder* window. Re-fitting
+        on the decoder window would leak future information into the scaling and
+        put the decoder target in a different space than ``target_past``.
+
+        Must therefore be called *after* ``fit_transform_sequence`` for the same
+        item. Non-per-sequence normalizers were already applied globally during
+        preprocessing, so they are passed through unchanged.
+
+        Parameters
+        ----------
+        data : tensor, ndarray, or Series
+            Shape ``(pred_length,)`` or ``(pred_length, n_targets)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Same shape as input.
+        """
+        if not self.is_multi:
+            return (
+                self.transform(data, X) if self.fit_per_sequence else _to_tensor(data)
+            )
+
+        t = _to_tensor(data)
+        if t.ndim == 1:
+            t = t.unsqueeze(-1)
+
+        columns = []
+        for idx, sub in enumerate(self._sub_adapters):
+            col = t[:, idx]
+            col = sub.transform(col, X) if sub.fit_per_sequence else col
+            columns.append(col.unsqueeze(-1))
+        return torch.cat(columns, dim=-1)

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -797,6 +797,14 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
             y = data["target"][decoder_indices]
 
+            # Apply the encoder normalizer to the decoder target as well, reusing
+            # the parameters fitted on this item's encoder window above, so that
+            # y lives in the same space as x["target_past"]. Note this transforms
+            # rather than re-fits: fitting on the decoder window would leak future
+            # values into the scaling.
+            if normalizer is not None and normalizer.fit_per_sequence:
+                y = normalizer.transform_sequence(y)
+
             if y.shape[-1] > 1:
                 y = [y[:, i] for i in range(y.shape[-1])]
             else:

--- a/tests/test_data/test_data_module.py
+++ b/tests/test_data/test_data_module.py
@@ -626,6 +626,138 @@ def test_target_normalizers(sample_timeseries_data, normalizer):
         dm_with_norm._target_normalizer_fitted = False
 
 
+def _trending_timeseries(n_targets=1):
+    """Deterministic strongly-trending series.
+
+    A trend makes the decoder window sit well away from the encoder window's mean,
+    so "normalized with the encoder window's parameters" is distinguishable both
+    from "left raw" and from "re-fitted on the decoder window".
+    """
+    rows = []
+    for g in range(3):
+        for t in range(60):
+            base = 500.0 + 20.0 * t + 100.0 * g
+            row = {
+                "group": g,
+                "time": pd.Timestamp("2020-01-01") + pd.Timedelta(days=t),
+                "target1": base,
+                "feature1": float(t % 5),
+            }
+            if n_targets > 1:
+                row["target2"] = base * 2.0
+            rows.append(row)
+    df = pd.DataFrame(rows)
+    return TimeSeries(
+        data=df,
+        time="time",
+        target="target1" if n_targets == 1 else ["target1", "target2"],
+        group=["group"],
+        num=["feature1"],
+    )
+
+
+def _make_dm(ts, normalizer):
+    dm = EncoderDecoderTimeSeriesDataModule(
+        time_series_dataset=ts,
+        max_encoder_length=20,
+        max_prediction_length=5,
+        batch_size=2,
+        target_normalizer=normalizer,
+    )
+    dm.setup(stage="fit")
+    return dm
+
+
+def _raw_window(dm, idx=0):
+    """Raw (pre-normalization) encoder and decoder targets for dataset item ``idx``.
+
+    Read from the data module's own cache so the comparison always refers to the
+    same window as ``dm.train_dataset[idx]``, independent of how series are split.
+    """
+    dataset = dm.train_dataset
+    series_idx, start, enc_length, pred_length = dataset.windows[idx]
+    raw = dataset.preprocessed_data[series_idx]["target_original"]
+    end = start + enc_length + pred_length
+    return raw[start : start + enc_length], raw[start + enc_length : end]
+
+
+def test_encoder_normalizer_normalizes_decoder_target():
+    """`y` must be normalized when using EncoderNormalizer.
+
+    Regression test for #2360: ``target_past`` was normalized in ``__getitem__``
+    but ``y`` was returned raw, so the target sat in a different space than the
+    encoder input.
+    """
+    dm = _make_dm(_trending_timeseries(), EncoderNormalizer())
+    _, y = dm.train_dataset[0]
+    raw_past, raw_y = _raw_window(dm)
+
+    # y must no longer be the raw decoder target.
+    assert not torch.allclose(
+        y, raw_y.squeeze(-1)
+    ), "y is still raw - decoder target was not normalized by EncoderNormalizer"
+
+    # y must equal the raw decoder target transformed with the parameters fitted
+    # on this item's encoder window.
+    reference = EncoderNormalizer()
+    reference.fit(raw_past.squeeze(-1))
+    expected = reference.transform(raw_y.squeeze(-1))
+
+    assert torch.allclose(y, expected, atol=1e-4), (
+        f"y not transformed with encoder-window parameters: "
+        f"got {y.tolist()}, expected {expected.tolist()}"
+    )
+
+
+def test_encoder_normalizer_decoder_target_does_not_refit():
+    """`y` must be transformed with encoder parameters, not re-fitted.
+
+    Re-fitting the normalizer on the decoder window would leak future information
+    into the scaling and would put `y` in a different space than ``target_past``.
+    On a trending series a re-fit would force `y` to zero mean / unit variance.
+    """
+    dm = _make_dm(_trending_timeseries(), EncoderNormalizer())
+    _, y = dm.train_dataset[0]
+
+    assert abs(float(y.mean())) > 0.5, (
+        "y appears re-fitted on the decoder window (mean collapsed to ~0); "
+        "it must reuse the parameters fitted on the encoder window"
+    )
+
+
+def test_encoder_normalizer_normalizes_decoder_target_multivariate():
+    """Per-sequence sub-normalizers normalize `y`; others are left untouched.
+
+    The decoder target must receive exactly the same treatment as ``target_past``
+    column by column, so the two stay in the same space.
+    """
+    # target1 -> per-sequence (EncoderNormalizer), target2 -> not per-sequence.
+    dm = _make_dm(
+        _trending_timeseries(n_targets=2), [EncoderNormalizer(), TorchNormalizer()]
+    )
+    x, y = dm.train_dataset[0]
+    raw_past, raw_y = _raw_window(dm)
+
+    assert len(y) == 2
+
+    # Per-sequence column: transformed with this item's encoder-window parameters.
+    reference = EncoderNormalizer()
+    reference.fit(raw_past[:, 0])
+    expected = reference.transform(raw_y[:, 0])
+    assert torch.allclose(
+        y[0], expected, atol=1e-4
+    ), "per-sequence decoder target not transformed with encoder-window parameters"
+
+    # Non-per-sequence column: `target_past` is passed through untouched by
+    # fit_transform_sequence, so `y` must be passed through untouched too.
+    assert torch.allclose(
+        x["target_past"][:, 1], raw_past[:, 1], atol=1e-4
+    ), "unexpected: non-per-sequence encoder target was altered"
+    assert torch.allclose(
+        y[1], raw_y[:, 1], atol=1e-4
+    ), "non-per-sequence decoder target must be left untouched, matching target_past"
+
+
 @pytest.mark.parametrize(
     "scaler_type",
     [


### PR DESCRIPTION
LLM generated content, by claude-opus-5

*(Disclosed per the note in this repository's pull request template. The change was
reviewed, executed and verified locally by a human-directed workflow; all test output
quoted below was produced on this branch.)*

#### Reference Issues/PRs

Fixes #2360.

Touches the same code path as #2302, which introduced the per-sequence scaler handling.

#### What does this implement/fix? Explain your changes.

With an `EncoderNormalizer`, `EncoderDecoderTimeSeriesDataModule` returned a decoder
target `y` that was never normalized, so `y` sat in a different space than
`x["target_past"]`.

The reason it is skipped entirely rather than merely inconsistent: `_normalize_target`
applies the global transform only when the normalizer is *not* per-sequence.

```python
if not self._target_normalizer.fit_per_sequence:
    target = self._target_normalizer.transform(target, X)
```

So for an `EncoderNormalizer` the cached `data["target"]` stays raw for the whole
series, and normalization is deferred to `__getitem__`. There, `target_past` is
fitted-and-transformed on the encoder window, but `y` was taken straight from that
still-raw cache. Net effect: the encoder input is standardized while the training
target is not.

Reproduction on `main` (deterministic series with a strong trend, encoder length 20,
prediction length 5):

```
target_past: mean=-0.0000 std=1.0000 min=-1.598 max=+1.556
y[0]       : mean=+941.7448 std=32.8716 min=+903.716 max=+983.395
```

The fix adds `ScalerAdapter.transform_sequence`, a companion to the existing
`fit_transform_sequence`, and applies it to `y`:

- it **transforms** using the parameters `fit_transform_sequence` just fitted on the
  encoder window, rather than re-fitting on the decoder window. Re-fitting would leak
  future values into the scaling and would put `y` in a different space than
  `target_past` — arguably worse than the original bug;
- it mirrors `fit_transform_sequence` column-by-column for `MultiNormalizer`, so
  non-per-sequence sub-normalizers are passed through untouched and never
  double-normalized.

After the fix the same window gives `y[0]: mean=+2.1108 std=0.2769`, which is the
arithmetically expected result: the encoder window spans 500→880 (mean ≈ 691,
std ≈ 118.7) and the decoder window sits at ≈ 941, so
`(941 − 691) / 118.7 ≈ 2.11`. `std` stays at 0.277 rather than collapsing to 1.0,
confirming the encoder parameters were reused instead of re-fitted.

#### What should a reviewer concentrate their feedback on?

- [ ] **Transform vs re-fit.** I took "normalize `y`" to mean "apply the encoder
  window's fitted parameters", not "fit on the decoder window". Please confirm that
  matches your intent, since it is the one genuinely semantic decision here.
- [ ] **Placement of the new method.** `transform_sequence` lives on `ScalerAdapter`
  next to `fit_transform_sequence`. Happy to inline it in the data module instead if
  you would rather not widen the adapter's public surface.
- [ ] **Pre-existing gap I deliberately did not touch.** For a `MultiNormalizer` that
  *mixes* per-sequence and global normalizers, `ScalerAdapter.fit_per_sequence` is
  `any(...)`, so `_normalize_target` skips the global transform for **every** column —
  meaning the non-per-sequence targets are currently never normalized at all. That is
  independent of this issue, so I left it alone and only kept the decoder side
  symmetric with the encoder side. Happy to open a separate issue if that is a real
  bug rather than intended.

#### Did you add any tests for the change?

Yes, three in `tests/test_data/test_data_module.py`:

| Test | Purpose |
| --- | --- |
| `test_encoder_normalizer_normalizes_decoder_target` | `y` equals the raw decoder target transformed with the encoder window's fitted parameters. **Fails on `main`.** |
| `test_encoder_normalizer_normalizes_decoder_target_multivariate` | `MultiNormalizer`: per-sequence column transformed, non-per-sequence column left untouched. **Fails on `main`.** |
| `test_encoder_normalizer_decoder_target_does_not_refit` | Guards against a *re-fit* implementation. Passes on `main` too — it constrains the fix rather than reproducing the bug. |

Expectations are derived from the data module's own `target_original` cache for the
same window, so they do not depend on two data modules happening to select the same
series.

Verification run locally on Windows / Python 3.13 / torch 2.13.0+cpu:

```
# full suite, with the fix
python -m pytest tests -q
429 passed, 15 skipped in 133.22s
# (15 skips are environmental: cpflows/matplotlib absent, known Windows-only skips)

# new tests with the source change reverted, tests kept
python -m pytest tests/test_data/test_data_module.py -k decoder_target
2 failed, 1 passed
  E  AssertionError: y is still raw - decoder target was not normalized by EncoderNormalizer
  E  AssertionError: per-sequence decoder target not transformed with encoder-window parameters

# repo pre-commit hooks, as the code-quality job runs them
pre-commit run --files <changed files>
  trim trailing whitespace...Passed   fix end of files...Passed
  check python ast...Passed           ruff...Passed        ruff-format...Passed
```

The new tests were run three times consecutively to check they are not order- or
seed-dependent.

#### Any other comments?

The diff is 181 added lines and no deletions or modifications to existing logic. I did
not add a `CHANGELOG.md` entry, following #2302 / #2300 / #2256 which leave it to
maintainers at release time — glad to add one if you prefer.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`
